### PR TITLE
Get audio sample rate from AudioStream header

### DIFF
--- a/teensy4/AudioStream.h
+++ b/teensy4/AudioStream.h
@@ -34,7 +34,6 @@
 #ifndef __ASSEMBLER__
 #include <stdio.h>  // for NULL
 #include <string.h> // for memcpy
-
 #endif
 
 // AUDIO_BLOCK_SAMPLES determines how many samples the audio library processes
@@ -60,23 +59,23 @@
 
 #define AUDIO_SAMPLE_RATE AUDIO_SAMPLE_RATE_EXACT
 
-#define noAUDIO_DEBUG_CLASS // disable this class by default
-
-#ifndef __ASSEMBLER__
-class AudioStream;
-class AudioConnection;
-#if defined(AUDIO_DEBUG_CLASS)
-class AudioDebug;  // for testing only, never for public release
-#endif // defined(AUDIO_DEBUG_CLASS)
-
+#if !defined(__ASSEMBLER__)
 typedef struct audio_block_struct {
 	uint8_t  ref_count;
 	uint8_t  reserved1;
 	uint16_t memory_pool_index;
 	int16_t  data[AUDIO_BLOCK_SAMPLES];
 } audio_block_t;
+#endif // !defined(__ASSEMBLER__)
 
+#define noAUDIO_DEBUG_CLASS // disable this class by default
 
+#if defined(__cplusplus)
+class AudioStream;
+class AudioConnection;
+#if defined(AUDIO_DEBUG_CLASS)
+class AudioDebug;  // for testing only, never for public release
+#endif // defined(AUDIO_DEBUG_CLASS)
 
 class AudioConnection
 {
@@ -212,5 +211,5 @@ class AudioDebug
 };
 #endif // defined(AUDIO_DEBUG_CLASS)
 
-#endif // __ASSEMBLER__
+#endif // defined(__cplusplus)
 #endif // AudioStream_h

--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -16,6 +16,7 @@
 #include "avr/pgmspace.h"
 #include <string.h>
 #include "debug/printf.h"
+#include "AudioStream.h"
 
 //#define LOG_SIZE  20
 //uint32_t transfer_log_head=0;
@@ -661,9 +662,9 @@ static void endpoint0_setup(uint64_t setupdata)
 		break;
 	  case 0x81A2: // GET_CUR (wValue=0, wIndex=interface, wLength=len)
 		if (setup.wLength >= 3) {
-			endpoint0_buffer[0] = 44100 & 255;
-			endpoint0_buffer[1] = 44100 >> 8;
-			endpoint0_buffer[2] = 0;
+			endpoint0_buffer[0] = ((int)(AUDIO_SAMPLE_RATE_EXACT)) & 0xff;
+			endpoint0_buffer[1] = (((int)(AUDIO_SAMPLE_RATE_EXACT)) >> 8) & 0xff;
+			endpoint0_buffer[2] = (((int)(AUDIO_SAMPLE_RATE_EXACT)) >> 16) & 0xff;
 			endpoint0_transmit(endpoint0_buffer, 3, 0);
 			return;
 		}

--- a/teensy4/usb_audio.h
+++ b/teensy4/usb_audio.h
@@ -78,10 +78,8 @@ public:
 	}
 private:
 	static bool update_responsibility;
-	static audio_block_t *incoming_left;
-	static audio_block_t *incoming_right;
-	static audio_block_t *ready_left;
-	static audio_block_t *ready_right;
+	static audio_block_t *incoming[AUDIO_CHANNELS];
+	static audio_block_t *ready[AUDIO_CHANNELS];
 	static uint16_t incoming_count;
 	static uint8_t receive_flag;
 };
@@ -89,7 +87,7 @@ private:
 class AudioOutputUSB : public AudioStream
 {
 public:
-	AudioOutputUSB(void) : AudioStream(2, inputQueueArray) { begin(); }
+	AudioOutputUSB(void) : AudioStream(AUDIO_CHANNELS, inputQueueArray) { begin(); }
 	virtual void update(void);
 	void begin(void);
 	friend unsigned int usb_audio_transmit_callback(void);
@@ -100,7 +98,7 @@ private:
 	static audio_block_t *right_1st;
 	static audio_block_t *right_2nd;
 	static uint16_t offset_1st;
-	audio_block_t *inputQueueArray[2];
+	audio_block_t *inputQueueArray[AUDIO_CHANNELS];
 };
 #endif // __cplusplus
 

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -1387,6 +1387,13 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 #endif // KEYMEDIA_INTERFACE
 
 #ifdef AUDIO_INTERFACE
+#define AUDIO_SAMPLE_FREQ(frq) (uint8_t)(frq), (uint8_t)((frq >> 8)), (uint8_t)((frq >> 16))
+
+ // Max packet size: (freq / 1000 + extra_samples) * channels * bytes_per_sample
+ // e.g. (48000 / 1000 + 1) * 2(stereo) * 3(24bit) = 388
+#define AUDIO_PACKET_SZE_24B(frq) (uint8_t)(((frq / 1000U + 1) * 4U * 3U) & 0xFFU), \
+                                  (uint8_t)((((frq / 1000U + 1) * 4U * 3U) >> 8) & 0xFFU)
+
 	// configuration for 480 Mbit/sec speed
         // interface association descriptor, USB ECN, Table 9-Z
         8,                                      // bLength
@@ -1428,7 +1435,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	//0x03, 0x06,				// wTerminalType, 0x0603 = Line Connector
 	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
 	0,					// bAssocTerminal, 0 = unidirectional
-	2,					// bNrChannels
+	AUDIO_CHANNELS,					// bNrChannels
 	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
@@ -1450,7 +1457,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	3,					// bTerminalID
 	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
 	0,					// bAssocTerminal, 0 = unidirectional
-	2,					// bNrChannels
+	AUDIO_CHANNELS,					// bNrChannels
 	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
@@ -1512,11 +1519,11 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType = CS_INTERFACE
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
-	2,					// bNrChannels = 2
-	2,					// bSubFrameSize = 2 byte
-	16,					// bBitResolution = 16 bits
+	AUDIO_CHANNELS,					// bNrChannels = 2
+	AUDIO_SAMPLE_BYTES,					// bSubFrameSize = 2 byte
+	AUDIO_BIT_DEPTH,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+	AUDIO_SAMPLE_FREQ(44100),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -1571,11 +1578,11 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType = CS_INTERFACE
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
-	2,					// bNrChannels = 2
-	2,					// bSubFrameSize = 2 byte
-	16,					// bBitResolution = 16 bits
+	AUDIO_CHANNELS,					// bNrChannels = 2
+	AUDIO_SAMPLE_BYTES,					// bSubFrameSize = 2 byte
+	AUDIO_BIT_DEPTH,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+	AUDIO_SAMPLE_FREQ(44100),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -2442,7 +2449,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	//0x03, 0x06,				// wTerminalType, 0x0603 = Line Connector
 	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
 	0,					// bAssocTerminal, 0 = unidirectional
-	2,					// bNrChannels
+	AUDIO_CHANNELS,					// bNrChannels
 	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
@@ -2464,7 +2471,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	3,					// bTerminalID
 	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
 	0,					// bAssocTerminal, 0 = unidirectional
-	2,					// bNrChannels
+	AUDIO_CHANNELS,					// bNrChannels
 	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
@@ -2526,7 +2533,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType = CS_INTERFACE
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
-	2,					// bNrChannels = 2
+	AUDIO_CHANNELS,					// bNrChannels = 2
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
@@ -2585,7 +2592,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType = CS_INTERFACE
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
-	2,					// bNrChannels = 2
+	AUDIO_CHANNELS,					// bNrChannels = 2
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -37,6 +37,7 @@
 #include "imxrt.h"
 #include "avr_functions.h"
 #include "avr/pgmspace.h"
+#include "AudioStream.h"
 
 // At very slow CPU speeds, the OCRAM just isn't fast enough for
 // USB to work reliably.  But the precious/limited DTCM is.  So
@@ -69,8 +70,9 @@
 //   USB Device
 // **************************************************************
 
-#define LSB(n) ((n) & 255)
-#define MSB(n) (((n) >> 8) & 255)
+#define LSB(n) ((int)(n) & 255)
+#define MSB(n) (((int)(n) >> 8) & 255)
+#define HSB(n) (((int)(n) >> 16) & 255)
 
 #ifdef CDC_IAD_DESCRIPTOR
 #ifndef DEVICE_CLASS

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -1525,7 +1525,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	AUDIO_SAMPLE_BYTES,					// bSubFrameSize = 2 byte
 	AUDIO_BIT_DEPTH,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	AUDIO_SAMPLE_FREQ(44100),		// tSamFreq
+	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -1584,7 +1584,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	AUDIO_SAMPLE_BYTES,					// bSubFrameSize = 2 byte
 	AUDIO_BIT_DEPTH,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	AUDIO_SAMPLE_FREQ(44100),		// tSamFreq
+	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -2539,7 +2539,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -2598,7 +2598,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -2536,8 +2536,8 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
 	AUDIO_CHANNELS,					// bNrChannels = 2
-	2,					// bSubFrameSize = 2 byte
-	16,					// bBitResolution = 16 bits
+	AUDIO_SAMPLE_BYTES,	// bSubFrameSize = 2 byte
+	AUDIO_BIT_DEPTH,	// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
 	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
@@ -2595,8 +2595,8 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
 	AUDIO_CHANNELS,					// bNrChannels = 2
-	2,					// bSubFrameSize = 2 byte
-	16,					// bBitResolution = 16 bits
+	AUDIO_SAMPLE_BYTES,	// bSubFrameSize = 2 byte
+	AUDIO_BIT_DEPTH,	// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
 	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -763,11 +763,10 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_INTERFACE	1	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     3
   #define AUDIO_CHANNELS        8 // Must be a multiple of 2
-  #define AUDIO_FREQUENCY       44100
-  #define AUDIO_BIT_DEPTH       16
-  #define AUDIO_SAMPLE_BYTES    AUDIO_BIT_DEPTH / 8
+  #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
+  #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
+  #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
   #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
-  // #define AUDIO_TX_SIZE         180
   #define AUDIO_RX_ENDPOINT     3
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	4
@@ -806,9 +805,13 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MIDI_RX_SIZE_480      512
   #define AUDIO_INTERFACE	3	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     5
-  #define AUDIO_TX_SIZE         180
+  #define AUDIO_CHANNELS        8 // Must be a multiple of 2
+  #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
+  #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
+  #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
+  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     5
-  #define AUDIO_RX_SIZE         180
+  #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	6
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
@@ -848,9 +851,13 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MIDI_RX_SIZE_480      512
   #define AUDIO_INTERFACE	3	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     5
-  #define AUDIO_TX_SIZE         180
+  #define AUDIO_CHANNELS        8 // Must be a multiple of 2
+  #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
+  #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
+  #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
+  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     5
-  #define AUDIO_RX_SIZE         180
+  #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	6
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
@@ -930,9 +937,13 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define KEYMEDIA_INTERVAL     4
   #define AUDIO_INTERFACE	9	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     13
-  #define AUDIO_TX_SIZE         180
+  #define AUDIO_CHANNELS        8 // Must be a multiple of 2
+  #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
+  #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
+  #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
+  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     13
-  #define AUDIO_RX_SIZE         180
+  #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	14
   #define MULTITOUCH_INTERFACE  12	// Touchscreen
   #define MULTITOUCH_ENDPOINT   15

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -766,7 +766,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
   #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
   #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
-  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
+  #define AUDIO_TX_SIZE         ((int)(AUDIO_FREQUENCY / 1000U) + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     3
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	4
@@ -809,7 +809,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
   #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
   #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
-  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
+  #define AUDIO_TX_SIZE         ((int)(AUDIO_FREQUENCY / 1000U) + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     5
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	6
@@ -855,7 +855,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
   #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
   #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
-  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
+  #define AUDIO_TX_SIZE         ((int)(AUDIO_FREQUENCY / 1000U) + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     5
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	6
@@ -941,7 +941,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
   #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
   #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
-  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
+  #define AUDIO_TX_SIZE         ((int)(AUDIO_FREQUENCY / 1000U) + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     13
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	14

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -762,9 +762,14 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define SEREMU_RX_INTERVAL    2
   #define AUDIO_INTERFACE	1	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     3
-  #define AUDIO_TX_SIZE         180
+  #define AUDIO_CHANNELS        8 // Must be a multiple of 2
+  #define AUDIO_FREQUENCY       44100
+  #define AUDIO_BIT_DEPTH       16
+  #define AUDIO_SAMPLE_BYTES    AUDIO_BIT_DEPTH / 8
+  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
+  // #define AUDIO_TX_SIZE         180
   #define AUDIO_RX_ENDPOINT     3
-  #define AUDIO_RX_SIZE         180
+  #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	4
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_INTERRUPT + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_ISOCHRONOUS + ENDPOINT_TRANSMIT_ISOCHRONOUS


### PR DESCRIPTION
Test pull request, to see if we can make this work! For some reason it thinks I've made all your changes and the merge can't be done automatically :-(

- USB code now uses the bit rate defined in AudioStream.h, and also gets the sample bit depth from there. 
- Multi-channel USB copied to all other build types (i.e. those adding MIDI and Serial to the Audio)