### PR TITLE
Fixes for common sample rate and correct buffer sizes

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -16,6 +16,7 @@
 #include "avr/pgmspace.h"
 #include <string.h>
 #include "debug/printf.h"
+#include "AudioStream.h"
 
 //#define LOG_SIZE  20
 //uint32_t transfer_log_head=0;
@@ -661,9 +662,9 @@ static void endpoint0_setup(uint64_t setupdata)
 		break;
 	  case 0x81A2: // GET_CUR (wValue=0, wIndex=interface, wLength=len)
 		if (setup.wLength >= 3) {
-			endpoint0_buffer[0] = 44100 & 255;
-			endpoint0_buffer[1] = 44100 >> 8;
-			endpoint0_buffer[2] = 0;
+			endpoint0_buffer[0] = ((int)(AUDIO_SAMPLE_RATE_EXACT)) & 0xff;
+			endpoint0_buffer[1] = (((int)(AUDIO_SAMPLE_RATE_EXACT)) >> 8) & 0xff;
+			endpoint0_buffer[2] = (((int)(AUDIO_SAMPLE_RATE_EXACT)) >> 16) & 0xff;
 			endpoint0_transmit(endpoint0_buffer, 3, 0);
 			return;
 		}

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -2536,8 +2536,8 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
 	AUDIO_CHANNELS,					// bNrChannels = 2
-	2,					// bSubFrameSize = 2 byte
-	16,					// bBitResolution = 16 bits
+	AUDIO_SAMPLE_BYTES,	// bSubFrameSize = 2 byte
+	AUDIO_BIT_DEPTH,	// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
 	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
@@ -2595,8 +2595,8 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
 	AUDIO_CHANNELS,					// bNrChannels = 2
-	2,					// bSubFrameSize = 2 byte
-	16,					// bBitResolution = 16 bits
+	AUDIO_SAMPLE_BYTES,	// bSubFrameSize = 2 byte
+	AUDIO_BIT_DEPTH,	// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
 	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -766,7 +766,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
   #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
   #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
-  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
+  #define AUDIO_TX_SIZE         ((int)(AUDIO_FREQUENCY / 1000U) + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     3
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	4
@@ -809,7 +809,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
   #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
   #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
-  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
+  #define AUDIO_TX_SIZE         ((int)(AUDIO_FREQUENCY / 1000U) + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     5
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	6
@@ -855,7 +855,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
   #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
   #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
-  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
+  #define AUDIO_TX_SIZE         ((int)(AUDIO_FREQUENCY / 1000U) + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     5
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	6
@@ -941,7 +941,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
   #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
   #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
-  #define AUDIO_TX_SIZE         (AUDIO_FREQUENCY / 1000U + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
+  #define AUDIO_TX_SIZE         ((int)(AUDIO_FREQUENCY / 1000U) + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
   #define AUDIO_RX_ENDPOINT     13
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	14


### PR DESCRIPTION
usb.c - don't assume 44.1kHz
usb_desc.c - use macros for sample size, not fixed values 
usb_desc.h - improved rounding for USB buffer sizes

Yup, this looks better, thanks for the git guidance!

I've tested this at 48kHz, changed _only_ in AudioStream.h, and apart from Windows giving me a hard time (I used USBDeview to uninstall the old Teensy device) it seems to work OK. 

I'll give 96kHz a try next, but I think a different buffer strategy (not using two sets of audio blocks) is needed really. 

Oh, and it needs testing on a Full Speed interface, I noticed using USBTreeView that "bInterval" is set to 4ms - does that mean we need to buffer (at least) 4ms of audio? That may be OK up to 48kHz (1 block is 2.67ms), but I think the USB code assumes 1ms (all those /1000 calculations!).