### PR TITLE
Better documentation for USB descriptor

### DIFF
--- a/teensy4/usb_audio.cpp
+++ b/teensy4/usb_audio.cpp
@@ -38,7 +38,11 @@
 bool AudioInputUSB::update_responsibility;
 audio_block_t * AudioInputUSB::incoming[AUDIO_CHANNELS];
 audio_block_t * AudioInputUSB::ready[AUDIO_CHANNELS];
-uint16_t AudioInputUSB::incoming_count;
+
+// The current amount that the incoming (pending) buffer is full. Between 0 and AUDIO_BLOCK_SAMPLES.
+uint16_t AudioInputUSB::incoming_count; 
+
+// A flag that there's data available for the next AudioStream consumer.
 uint8_t AudioInputUSB::receive_flag;
 
 struct usb_audio_features_struct AudioInputUSB::features = {0,0,FEATURE_MAX_VOLUME/2};
@@ -59,11 +63,16 @@ uint8_t usb_audio_transmit_setting=0;
 uint8_t usb_audio_sync_nbytes;
 uint8_t usb_audio_sync_rshift;
 
+// In the USB documentation:
+// Fs: The *actual* sample rate currently witnessed, as measured relative to the USB (micro)frames SOF.
+//     so, for Full-Speed that would be every 1ms, and for High-Speed every 125us (8x faster).
+// Ff: The *desired* data rate to achieve a target sample rate.
 uint32_t feedback_accumulator;
 
 volatile uint32_t usb_audio_underrun_count;
 volatile uint32_t usb_audio_overrun_count;
 
+volatile uint32_t sync_counter = 0, callback_counter = 0, samples_counted = 0;
 
 static void rx_event(transfer_t *t)
 {
@@ -74,14 +83,20 @@ static void rx_event(transfer_t *t)
 	}
 	usb_prepare_transfer(&rx_transfer, rx_buffer, AUDIO_RX_SIZE, 0);
 	arm_dcache_delete(&rx_buffer, AUDIO_RX_SIZE);
-	usb_receive(AUDIO_RX_ENDPOINT, &rx_transfer);
+	usb_receive(AUDIO_RX_EP, &rx_transfer);
 }
 
 static void sync_event(transfer_t *t)
 {
+	sync_counter++;
 	// USB 2.0 Specification, 5.12.4.2 Feedback, pages 73-75
-	//printf("sync %x\n", sync_transfer.status); // too slow, can't print this much
 	usb_audio_sync_feedback = feedback_accumulator >> usb_audio_sync_rshift;
+	// if (sync_counter % 4000 == 0) {
+	// 	char c[10];
+	// 	float feedback_float = (float)usb_audio_sync_feedback / (float)(1<<16);
+	// 	snprintf(c, 9, "%.6f", feedback_float);
+	// 	printf("sync %s\n", c); // too slow, can't print this much
+	// }
 	usb_prepare_transfer(&sync_transfer, &usb_audio_sync_feedback, usb_audio_sync_nbytes, 0);
 	arm_dcache_flush(&usb_audio_sync_feedback, usb_audio_sync_nbytes);
 	usb_transmit(AUDIO_SYNC_ENDPOINT, &sync_transfer);
@@ -92,7 +107,21 @@ void usb_audio_configure(void)
 	printf("usb_audio_configure\n");
 	usb_audio_underrun_count = 0;
 	usb_audio_overrun_count = 0;
+
+
+	// The feedback accumulator keeps track of how many samples have been seen
+	// based on the USB Host's clock, which for USB FS triggers every 1ms, and for
+	// USB HS triggers 8 times per 1ms (every 125us).
+	//
+	// We're multiplying by 2^24 here as a convenience for formatting the response
+	// to the host, which expects:
+	//   if High-Speed (480Mbps): An unsigned 10.10 fixed point binary, aligned as a 3-byte 10.14.
+	//   if Full-Speed ( 12Mbps): An unsigned 10.14 fixed point binary, aligned as a 4-byte 16.16.
+	// thus, the 
+	//
 	feedback_accumulator = (AUDIO_SAMPLE_RATE_EXACT / 1000.0f) * 0x1000000; // samples/millisecond * 2^24
+	// USB 2.0 High-Speed uses a 4-byte feedback format,
+	// where Full Speed uses a 3-byte format.
 	if (usb_high_speed) {
 		usb_audio_sync_nbytes = 4;
 		usb_audio_sync_rshift = 8;
@@ -101,13 +130,13 @@ void usb_audio_configure(void)
 		usb_audio_sync_rshift = 10;
 	}
 	memset(&rx_transfer, 0, sizeof(rx_transfer));
-	usb_config_rx_iso(AUDIO_RX_ENDPOINT, AUDIO_RX_SIZE, 1, rx_event);
+	usb_config_rx_iso(AUDIO_RX_EP, AUDIO_RX_SIZE, 1, rx_event);
 	rx_event(NULL);
 	memset(&sync_transfer, 0, sizeof(sync_transfer));
 	usb_config_tx_iso(AUDIO_SYNC_ENDPOINT, usb_audio_sync_nbytes, 1, sync_event);
 	sync_event(NULL);
 	memset(&tx_transfer, 0, sizeof(tx_transfer));
-	usb_config_tx_iso(AUDIO_TX_ENDPOINT, AUDIO_TX_SIZE, 1, tx_event);
+	usb_config_tx_iso(AUDIO_TX_EP, AUDIO_TX_SIZE, 1, tx_event);
 	tx_event(NULL);
 }
 
@@ -126,7 +155,7 @@ void AudioInputUSB::begin(void)
 	// means we no longer get receive callbacks from usb.c
 	update_responsibility = false;
 }
-static void copy_to_buffers_redux(const uint32_t *src, audio_block_t *chans[AUDIO_CHANNELS], unsigned int count, unsigned int len) 
+static void copy_to_buffers(const uint32_t *src, audio_block_t *chans[AUDIO_CHANNELS], unsigned int count, unsigned int len) 
 {
 	uint32_t *target = (uint32_t*) src + (len * AUDIO_CHANNELS/2);
 
@@ -137,8 +166,8 @@ static void copy_to_buffers_redux(const uint32_t *src, audio_block_t *chans[AUDI
 			chans[j*2]->data[count+i] = n & 0xFFFF;
 			// NOTE: inverting this sample here because for some reason
 			// one of the channels has a phase issue...
-			// chans[j*2+1]->data[count+i] = UINT16_MAX - (n >> 16);
-			chans[j*2+1]->data[count+i] = n >> 16;
+			chans[j*2+1]->data[count+i] = UINT16_MAX - (n >> 16);
+			// chans[j*2+1]->data[count+i] = n >> 16;
 		}
 		i++;
 	}
@@ -155,16 +184,34 @@ void usb_audio_receive_callback(unsigned int len)
 	const uint16_t *data;
 	const uint32_t *data_orig;
 
+
 	AudioInputUSB::receive_flag = 1;
-	len /= AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES; // 1 sample = channels * bytes per sample
-	data = (const uint16_t *)rx_buffer;
+	// Let `len` now represent the number of "frames" of audio
+	// One frame includes exactly one sample per channel.
+	//
+	// For example, if we have 8 channels of 16-bit audio,
+	// one frame would be 16 bytes long.
+	len /= AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES;
+	samples_counted += len;
+	callback_counter++;
+	// if (callback_counter % 12000 == 0) {
+	// 	char c[10];
+	// 	float average = (float)samples_counted / (float)callback_counter;
+	// 	snprintf(c, 9, "%.2f", average * 8.0f * 1000.0f);
+	// 	printf("%s\n", c);
+	// 	samples_counted = 0;
+	// 	callback_counter = 0;
+	// }
+
+	// A moving pointer to the USB receive buffer as we eat it up.
 	data_orig = (const uint32_t *)rx_buffer;
 
 	count = AudioInputUSB::incoming_count;
+
+	// Either use the existing incoming buffers or allocate new ones as needed.
 	for (uint32_t i = 0; i < AUDIO_CHANNELS; i++) {
 		chans[i] = AudioInputUSB::incoming[i];
 	}
-
 	for (uint32_t i = 0; i < AUDIO_CHANNELS; i++) {
 		if (AudioInputUSB::incoming[i] == NULL) {
 			chans[i] = AudioStream::allocate();
@@ -175,20 +222,31 @@ void usb_audio_receive_callback(unsigned int len)
 	while (len > 0) {
 		avail = AUDIO_BLOCK_SAMPLES - count;
 		if (len < avail) {
-			copy_to_buffers_redux(data_orig, chans, count, len);
+			// We can fit the entire incoming buffer in one AudioStream block,
+			// so we simply copy the whole thing in.
+			copy_to_buffers(data_orig, chans, count, len);
 			AudioInputUSB::incoming_count = count + len;
 			return;
 		} else if (avail > 0) {
-			copy_to_buffers_redux(data_orig, chans, count, avail);
-			data_orig += avail * AUDIO_CHANNELS/2;
-			data += avail * AUDIO_CHANNELS;
+			// Otherwise, we will be finishing up filling a block, and can
+			// flush it to the next consumer in the chain.
+			//
+			// We'll need to finish consuming the data after that, though,
+			// which is why this looks complicated.
+			copy_to_buffers(data_orig, chans, count, avail);
+			data_orig += avail * AUDIO_CHANNELS / AUDIO_SAMPLE_BYTES;
 			len -= avail;
 			for (int i = 0; i < AUDIO_CHANNELS; i++) {
 				if (AudioInputUSB::ready[i]) {
+					// If the previous ready buffers have not been consumed,
+					// all we can do is fill up our current incoming buffer
+					// and wait to be able to swap them.
 					AudioInputUSB::incoming_count = count + avail;
 					if (len > 0) {
+						// If there were remaining bytes of audio, they will
+						// be dropped because there is nowhere to put them.
 						usb_audio_overrun_count++;
-						printf("!");
+						printf("^ OVERRUN ^\n");
 						//serial_phex(len);
 					}
 					return;
@@ -245,20 +303,21 @@ void AudioInputUSB::update(void)
 	receive_flag = 0;
 	__enable_irq();
 	if (f) {
+		// Did we receive more or less than half 
 		int diff = AUDIO_BLOCK_SAMPLES/2 - (int)c;
 		feedback_accumulator += diff * 1;
 		//uint32_t feedback = (feedback_accumulator >> 8) + diff * 100;
 		//usb_audio_sync_feedback = feedback;
 
-		//printf(diff >= 0 ? "." : "^");
+		// printf(diff >= 0 ? "." : "^");
 	}
 	//serial_phex(c);
 	//serial_print(".");
 	for (int i = 0; i < AUDIO_CHANNELS; i++) {
 		if (!chans[i]) {
 			usb_audio_underrun_count++;
-			// printf("#"); // buffer underrun - PC sending too slow
-			if (f) feedback_accumulator += 3500;
+			printf("v UNDERRUN v\n"); // buffer underrun - PC sending too slow
+			// if (f) feedback_accumulator += 3500;
 			break;
 		}
 	}
@@ -295,7 +354,7 @@ static void tx_event(transfer_t *t)
 	usb_audio_sync_feedback = feedback_accumulator >> usb_audio_sync_rshift;
 	usb_prepare_transfer(&tx_transfer, usb_audio_transmit_buffer, len, 0);
 	arm_dcache_flush_delete(usb_audio_transmit_buffer, len);
-	usb_transmit(AUDIO_TX_ENDPOINT, &tx_transfer);
+	usb_transmit(AUDIO_TX_EP, &tx_transfer);
 }
 
 

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -1389,16 +1389,6 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 #endif // KEYMEDIA_INTERFACE
 
 #ifdef AUDIO_INTERFACE
-#define AUDIO_SAMPLE_FREQ(frq) (uint8_t)(frq), (uint8_t)((frq >> 8)), (uint8_t)((frq >> 16))
-
- // Max packet size: (freq / 1000 + extra_samples) * channels * bytes_per_sample
- // e.g. (48000 / 1000 + 1) * 2(stereo) * 3(24bit) = 388
-#define AUDIO_PACKET_SZE_24B(frq) (uint8_t)(((frq / 1000U + 1) * 4U * 3U) & 0xFFU), \
-                                  (uint8_t)((((frq / 1000U + 1) * 4U * 3U) >> 8) & 0xFFU)
-
-#define AUDIO_CONTROL_MUTE 0x01
-#define AUDIO_CONTROL_VOL 0x02
-
       // configuration for 480 Mbit/sec speed
       // IAD (interface association descriptor), USB ECN, Table 9-Z
       // USB IAD allows the device to group interfaces that belong to a function.
@@ -1446,35 +1436,35 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
       //
       // See USB DCD for Terminal Types: https://www.usb.org/sites/default/files/termt10.pdf
       12,                   // bLength
-      0x24,                 // bDescriptorType, 0x24 = CS_INTERFACE
-      0x02,                 // bDescriptorSubType, 2 = INPUT_TERMINAL
+      CS_DESC_TYPE_INTERFACE,                 // bDescriptorType, 0x24 = CS_INTERFACE
+      CS_DESC_SUBTYPE_INPUT_TERMINAL,                 // bDescriptorSubType, 2 = INPUT_TERMINAL
       1,                    // bTerminalID (0x00 is reserved and invalid)
       0x02, 0x06,           // wTerminalType, 0x0602 = Digital Audio
       0,                    // bAssocTerminal, 0 = unidirectional
       AUDIO_CHANNELS,       // bNrChannels 
       0x03, 0x00,           // wChannelConfig, 0x0003 = Left & Right Front
-      // TODO(mcginty): should the above 2 fields always be the sameas the other channel configs?
+      // TODO(mcginty): should the above 2 fields always be the same as the other channel configs?
       0,                    // iChannelNames
       0,                    // iTerminal, optional string descriptor
 
       // Output Terminal Descriptor
       // USB DCD for Audio Devices 1.0, Table 4-4, page 40
       // This terminal is connected to the AudioStreaming interface.
-      9,                    // bLength
-      0x24,                 // bDescriptorType, 0x24 = CS_INTERFACE
-      3,                    // bDescriptorSubtype, 3 = OUTPUT_TERMINAL
-      2,                    // bTerminalID
-      0x01, 0x01,           // wTerminalType, 0x0101 = USB_STREAMING
-      0,                    // bAssocTerminal, 0 = unidirectional
-      1,                    // bCSourceID, connected to input terminal, ID=1
-      0,                    // iTerminal, optional string descriptor
+      9,                               // bLength
+      CS_DESC_TYPE_INTERFACE,          // bDescriptorType, 0x24 = CS_INTERFACE
+      CS_DESC_SUBTYPE_OUTPUT_TERMINAL, // bDescriptorSubtype, 3 = OUTPUT_TERMINAL
+      2,                               // bTerminalID
+      0x01, 0x01,                      // wTerminalType, 0x0101 = USB_STREAMING
+      0,                               // bAssocTerminal, 0 = unidirectional
+      1,                               // bSourceID, connected to input terminal, ID=1
+      0,                               // iTerminal, optional string descriptor
 
       // Input Terminal Descriptor
       // USB DCD for Audio Devices 1.0, Table 4-3, page 39
       // This terminal is connected to the AudioStreaming interface.
       12,                   // bLength
-      0x24,                 // bDescriptorType, 0x24 = CS_INTERFACE
-      2,                    // bDescriptorSubType, 2 = INPUT_TERMINAL
+      CS_DESC_TYPE_INTERFACE,                 // bDescriptorType, 0x24 = CS_INTERFACE
+      CS_DESC_SUBTYPE_INPUT_TERMINAL,                    // bDescriptorSubType, 2 = INPUT_TERMINAL
       3,                    // bTerminalID
       0x01, 0x01,           // wTerminalType, 0x0101 = USB_STREAMING
       0,                    // bAssocTerminal, 0 = unidirectional
@@ -1485,8 +1475,8 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 
       // Feature Unit Descriptor (Volume)
       10,                   // bLength
-      0x24,                 // bDescriptorType = CS_INTERFACE
-      0x06,                 // bDescriptorSubType = FEATURE_UNIT
+      CS_DESC_TYPE_INTERFACE,                 // bDescriptorType = CS_INTERFACE
+      CS_DESC_SUBTYPE_FEATURE_UNIT,                 // bDescriptorSubType = FEATURE_UNIT
       0x31,                 // bUnitID TODO(mcginty): why 0x31?
       0x03,                 // bSourceID (Input Terminal)
       0x01,                 // bControlSize (each channel is 1 byte, 3 channels)
@@ -1505,19 +1495,19 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
       //
       // See USB DCD for Terminal Types: https://www.usb.org/sites/default/files/termt10.pdf
       9,                    // bLength
-      0x24,                 // bDescriptorType, 0x24 = CS_INTERFACE
-      3,                    // bDescriptorSubtype, 3 = OUTPUT_TERMINAL
+      CS_DESC_TYPE_INTERFACE,                 // bDescriptorType, 0x24 = CS_INTERFACE
+      CS_DESC_SUBTYPE_OUTPUT_TERMINAL,                    // bDescriptorSubtype, 3 = OUTPUT_TERMINAL
       4,                    // bTerminalID
       0x02, 0x06,           // wTerminalType, 0x0602 = Digital Audio
       0,                    // bAssocTerminal, 0 = unidirectional
-      0x31,                 // bCSourceID, connected to feature, ID=31
+      0x31,                 // bSourceID, connected to feature, ID=31
       0,                    // iTerminal, optional string descriptor
 
       // Standard AS (AudioStreaming) Interface Descriptor
       // USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
       // Alternate 0: default setting, disabled zero bandwidth
       //
-      // This is for the OUTPUT capabilities (HOST => DEVICE)
+      // This is for the DEVICE TO HOST streaming
       //
       // This descriptor needs to have two "alternate settings"
       // 0: the default setting, "disabled mode", zero bandwidth, no endpoints
@@ -1545,7 +1535,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
       // Class-Specific AS Interface Descriptor
       // USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
       //
-      // This is for the OUTPUT streaming (HOST => DEVICE)
+      // This is for the DEVICE TO HOST streaming
       7,                    // bLength
       0x24,                 // bDescriptorType = CS_INTERFACE
       1,                    // bDescriptorSubtype, 1 = AS_GENERAL
@@ -1554,20 +1544,6 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
       // TODO(mcginty): ^ what is this 3ms from?
       0x01, 0x00,           // wFormatTag, 0x0001 = PCM
 
-      #define AUDIO_FORMAT_TYPE_I 0x01
-      #define USB_DESC_TYPE_INTERFACE 0x04
-      #define USB_DESC_TYPE_ENDPOINT 0x05
-
-      #define CS_DESC_TYPE_INTERFACE 0x24
-      #define CS_DESC_TYPE_ENDPOINT 0x25
-      #define CS_DESC_SUBTYPE_FORMAT 0x02
-      #define CS_DESC_SUBTYPE_EP_GENERAL 0x01
-      #define CS_DESC_SUBTYPE_AS_GENERAL 0x01
-
-      #define AUDIO_EP_IN_MASK 0x80 // A mask used to indicate a specified endpoint ID is an input
-      #define AUDIO_EP_TYPE_ISOC 0x01 // Isochronous Endpoint Type
-      #define AUDIO_EP_TYPE_ADAPTIVE 0x08 // Isochronous Endpoint Type
-      #define AUDIO_EP_TYPE_ASYNC 0x04 // Isochronous Endpoint Type
       // Type I Format Descriptor
       // USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
       // See: https://usb.org/sites/default/files/frmts10.pdf
@@ -1587,7 +1563,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
       USB_DESC_TYPE_ENDPOINT,                       // bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
       AUDIO_TX_EP | AUDIO_EP_IN_MASK,               // bEndpointAddress
       AUDIO_EP_TYPE_ISOC | AUDIO_EP_TYPE_ADAPTIVE,  // bmAttributes
-      // TODO(mcginty): above SHOULD be ASYNC, not ADAPTIVE
+      // TODO(mcginty): above should probably be ASYNC, not ADAPTIVE
       LSB(AUDIO_TX_SIZE), MSB(AUDIO_TX_SIZE),       // wMaxPacketSize
       1,                                            // bInterval, must be set to 1
       0,                                            // bRefresh TODO(mcginty): double-check on bRefresh
@@ -1606,7 +1582,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
       // USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
       // Alternate 0: default setting, disabled zero bandwidth
       //
-      // This is for the INPUT capabilities (DEVICE => HOST)
+      // This is for the HOST TO DEVICE streaming
       //
       // This descriptor needs to have two "alternate settings"
       // 0: the default setting, "disabled mode", zero bandwidth, no endpoints
@@ -1680,8 +1656,8 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
       0x11,                                     // bmAttributes = isochronous, feedback
       0x04, 0x00,                               // wMaxPacketSize, 4 bytes
       0x01,                                     // bInterval, must be set to 1
-      0x07,                                     // bRefresh, rate of feedback, as power of 2, eg. 2^7 = 128ms
-      // TODO(jake): do we want a 128ms feedback here?
+      0x07,                                     // bRefresh, rate of feedback, as power of 2
+      // TODO(jake): what bRefresh feedback rate do we want here?
       0x00,                                     // bSynchAddress
 #endif
 

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -1396,53 +1396,70 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 #define AUDIO_PACKET_SZE_24B(frq) (uint8_t)(((frq / 1000U + 1) * 4U * 3U) & 0xFFU), \
                                   (uint8_t)((((frq / 1000U + 1) * 4U * 3U) >> 8) & 0xFFU)
 
+#define AUDIO_CONTROL_MUTE 0x01
+#define AUDIO_CONTROL_VOL 0x02
+
 	// configuration for 480 Mbit/sec speed
-        // interface association descriptor, USB ECN, Table 9-Z
-        8,                                      // bLength
-        11,                                     // bDescriptorType
-        AUDIO_INTERFACE,                        // bFirstInterface
-        3,                                      // bInterfaceCount
-        0x01,                                   // bFunctionClass
-        0x01,                                   // bFunctionSubClass
-        0x00,                                   // bFunctionProtocol
-        0,                                      // iFunction
+	// IAD (interface association descriptor), USB ECN, Table 9-Z
+	// USB IAD allows the device to group interfaces that belong to a function.
+	// NOTE(mcginty): This seems to be used as the Teensy also has an HID function.
+	8,			// bLength
+	11,			// bDescriptorType
+	AUDIO_INTERFACE,	// bFirstInterface
+	3,			// bInterfaceCount
+	0x01,			// bFunctionClass, 0x01 = AUDIO
+	0x01,			// bFunctionSubClass
+	0x00,			// bFunctionProtocol
+	0,			// iFunction
+
 	// Standard AudioControl (AC) Interface Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-1, page 36
 	9,					// bLength
 	4,					// bDescriptorType, 4 = INTERFACE
 	AUDIO_INTERFACE,			// bInterfaceNumber
 	0,					// bAlternateSetting
-	0,					// bNumEndpoints
+	0,					// bNumEndpoints: 0  for the default, 1 if the optional status interrupt endpoint is present.
 	1,					// bInterfaceClass, 1 = AUDIO
 	1,					// bInterfaceSubclass, 1 = AUDIO_CONTROL
-	0,					// bInterfaceProtocol
-	0,					// iInterface
+	0,					// bInterfaceProtocol, unused (must be 0)
+	0,					// iInterface, optional index of a string descriptor that describes this interface.
+
 	// Class-specific AC Interface Header Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-2, page 37-38
-	10,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	0x01,					// bDescriptorSubtype, 1 = HEADER
-	0x00, 0x01,				// bcdADC (version 1.0)
-	LSB(62), MSB(62),			// wTotalLength
-	2,					// bInCollection
-	AUDIO_INTERFACE+1,			// baInterfaceNr(1) - Transmit to PC
-	AUDIO_INTERFACE+2,			// baInterfaceNr(2) - Receive from PC
+	// Followed by one or more unit and/or terminal descriptors (UD and TD, respectively).
+	10,				// bLength
+	0x24,				// bDescriptorType, 0x24 = CS_INTERFACE
+	0x01,				// bDescriptorSubtype, 1 = HEADER
+	0x00, 0x01,			// bcdADC (USB Audio Class v1.0)
+	LSB(62), MSB(62),		// wTotalLength
+	2,				// bInCollection
+	AUDIO_INTERFACE+1,	// baInterfaceNr(1) - Transmit to PC
+	AUDIO_INTERFACE+2,	// baInterfaceNr(2) - Receive from PC
+
 	// Input Terminal Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-3, page 39
+	//
+	// "External" terminal descriptor:
+	// This optional descriptor serves as a "documentation" terminal to let the host
+	// know that it should treat this terminal as a generic Digital Audio terminal, as opposed to
+	// an analog line connector, for example.
+	//
+	// See USB DCD for Terminal Types: https://www.usb.org/sites/default/files/termt10.pdf
 	12,					// bLength
 	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
 	0x02,					// bDescriptorSubType, 2 = INPUT_TERMINAL
-	1,					// bTerminalID
-	//0x01, 0x02,				// wTerminalType, 0x0201 = MICROPHONE
-	//0x03, 0x06,				// wTerminalType, 0x0603 = Line Connector
+	1,					// bTerminalID (0x00 is reserved and invalid)
 	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
 	0,					// bAssocTerminal, 0 = unidirectional
-	AUDIO_CHANNELS,					// bNrChannels
+	AUDIO_CHANNELS,			// bNrChannels 
 	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
+	// TODO(mcginty): should the above 2 fields always be the sameas the other channel configs?
 	0,					// iChannelNames
-	0, 					// iTerminal
+	0,					// iTerminal, optional string descriptor
+
 	// Output Terminal Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-4, page 40
+	// This terminal is connected to the AudioStreaming interface.
 	9,					// bLength
 	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
 	3,					// bDescriptorSubtype, 3 = OUTPUT_TERMINAL
@@ -1450,47 +1467,64 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
 	0,					// bAssocTerminal, 0 = unidirectional
 	1,					// bCSourceID, connected to input terminal, ID=1
-	0,					// iTerminal
+	0,					// iTerminal, optional string descriptor
+
 	// Input Terminal Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-3, page 39
-	12,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	2,					// bDescriptorSubType, 2 = INPUT_TERMINAL
-	3,					// bTerminalID
-	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
-	0,					// bAssocTerminal, 0 = unidirectional
-	AUDIO_CHANNELS,					// bNrChannels
-	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
-	0,					// iChannelNames
-	0, 					// iTerminal
-	// Volume feature descriptor
-	10,					// bLength
-	0x24, 				// bDescriptorType = CS_INTERFACE
-	0x06, 				// bDescriptorSubType = FEATURE_UNIT
-	0x31, 				// bUnitID
-	0x03, 				// bSourceID (Input Terminal)
-	0x01, 				// bControlSize (each channel is 1 byte, 3 channels)
-	0x01, 				// bmaControls(0) Master: Mute
-	0x02, 				// bmaControls(1) Left: Volume
-	0x02, 				// bmaControls(2) Right: Volume
-	0x00,				// iFeature
+	// This terminal is connected to the AudioStreaming interface.
+	12,				// bLength
+	0x24,				// bDescriptorType, 0x24 = CS_INTERFACE
+	2,				// bDescriptorSubType, 2 = INPUT_TERMINAL
+	3,				// bTerminalID
+	0x01, 0x01,			// wTerminalType, 0x0101 = USB_STREAMING
+	0,				// bAssocTerminal, 0 = unidirectional
+	AUDIO_CHANNELS,		// bNrChannels
+	0x03, 0x00,			// wChannelConfig, 0x0003 = Left & Right Front
+	0,				// iChannelNames
+	0,				// iTerminal, optional string descriptor
+
+	// Feature Unit Descriptor (Volume)
+	10,				// bLength
+	0x24,				// bDescriptorType = CS_INTERFACE
+	0x06,				// bDescriptorSubType = FEATURE_UNIT
+	0x31,				// bUnitID TODO(mcginty): why 0x31?
+	0x03,				// bSourceID (Input Terminal)
+	0x01,				// bControlSize (each channel is 1 byte, 3 channels)
+	AUDIO_CONTROL_MUTE,	// bmaControls(0) Master: Mute
+	AUDIO_CONTROL_VOL,	// bmaControls(1) Left: Volume TODO(mcginty): remove?
+	AUDIO_CONTROL_VOL,	// bmaControls(2) Right: Volume TODO(mcginty): remove?
+	0x00,				// iFeature, optional string descriptor
+
 	// Output Terminal Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-4, page 40
+	//
+	// "External" terminal descriptor:
+	// This optional descriptor serves as a "documentation" terminal to let the host
+	// know that it should treat this terminal as a generic Digital Audio terminal, as opposed to
+	// an analog line connector, for example.
+	//
+	// See USB DCD for Terminal Types: https://www.usb.org/sites/default/files/termt10.pdf
 	9,					// bLength
 	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
 	3,					// bDescriptorSubtype, 3 = OUTPUT_TERMINAL
 	4,					// bTerminalID
-	//0x02, 0x03,				// wTerminalType, 0x0302 = Headphones
 	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
 	0,					// bAssocTerminal, 0 = unidirectional
-	0x31,				// bCSourceID, connected to feature, ID=31
-	0,					// iTerminal
-	// Standard AS Interface Descriptor
+	0x31,				      // bCSourceID, connected to feature, ID=31
+	0,					// iTerminal, optional string descriptor
+
+	// Standard AS (AudioStreaming) Interface Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
 	// Alternate 0: default setting, disabled zero bandwidth
+	//
+	// This is for the OUTPUT capabilities (HOST => DEVICE)
+	//
+	// This descriptor needs to have two "alternate settings"
+	// 0: the default setting, "disabled mode", zero bandwidth, no endpoints
+	// 1: the "active" setting, full streaming endpoint
 	9,					// bLenght
 	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+1,			// bInterfaceNumber
+	AUDIO_INTERFACE+1,		// bInterfaceNumber
 	0,					// bAlternateSetting
 	0,					// bNumEndpoints
 	1,					// bInterfaceClass, 1 = AUDIO
@@ -1500,56 +1534,86 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	// Alternate 1: streaming data
 	9,					// bLenght
 	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+1,			// bInterfaceNumber
+	AUDIO_INTERFACE+1,		// bInterfaceNumber
 	1,					// bAlternateSetting
 	1,					// bNumEndpoints
 	1,					// bInterfaceClass, 1 = AUDIO
 	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
 	0,					// bInterfaceProtocol
 	0,					// iInterface
+
 	// Class-Specific AS Interface Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
+	//
+	// This is for the OUTPUT streaming (HOST => DEVICE)
 	7, 					// bLength
 	0x24,					// bDescriptorType = CS_INTERFACE
 	1,					// bDescriptorSubtype, 1 = AS_GENERAL
-	2,					// bTerminalLink: Terminal ID = 2
+	2,					// bTerminalLink: Terminal ID = 2 (USB_STREAMING Output Terminal)
 	3,					// bDelay (approx 3ms delay, audio lib updates)
+	// TODO(mcginty): ^ what is this 3ms from?
 	0x01, 0x00,				// wFormatTag, 0x0001 = PCM
+
+	#define AUDIO_FORMAT_TYPE_I 0x01
+	#define USB_DESC_TYPE_INTERFACE 0x04
+	#define USB_DESC_TYPE_ENDPOINT 0x05
+
+	#define CS_DESC_TYPE_INTERFACE 0x24
+	#define CS_DESC_TYPE_ENDPOINT 0x25
+	#define CS_DESC_SUBTYPE_FORMAT 0x02
+	#define CS_DESC_SUBTYPE_EP_GENERAL 0x01
+	#define CS_DESC_SUBTYPE_AS_GENERAL 0x01
+
+	#define AUDIO_EP_IN_MASK 0x80 // A mask used to indicate a specified endpoint ID is an input
+	#define AUDIO_EP_TYPE_ISOC 0x01 // Isochronous Endpoint Type
+	#define AUDIO_EP_TYPE_ADAPTIVE 0x08 // Isochronous Endpoint Type
+	#define AUDIO_EP_TYPE_ASYNC 0x04 // Isochronous Endpoint Type
 	// Type I Format Descriptor
 	// USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
+	// See: https://usb.org/sites/default/files/frmts10.pdf
 	11,					// bLength
-	0x24,					// bDescriptorType = CS_INTERFACE
-	2,					// bDescriptorSubtype = FORMAT_TYPE
-	1,					// bFormatType = FORMAT_TYPE_I
-	AUDIO_CHANNELS,					// bNrChannels = 2
-	AUDIO_SAMPLE_BYTES,					// bSubFrameSize = 2 byte
-	AUDIO_BIT_DEPTH,					// bBitResolution = 16 bits
-	1,					// bSamFreqType = 1 frequency
+	CS_DESC_TYPE_INTERFACE,		// bDescriptorType = CS_INTERFACE
+	CS_DESC_SUBTYPE_FORMAT,		// bDescriptorSubtype = FORMAT_TYPE
+	AUDIO_FORMAT_TYPE_I,		// bFormatType
+	AUDIO_CHANNELS,			// bNrChannels
+	AUDIO_SAMPLE_BYTES,		// bSubFrameSize (in bytes)
+	AUDIO_BIT_DEPTH,			// bBitResolution
+	1,					// bSamFreqType (number of frequencies supported)
 	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
+
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
-	9, 					// bLength
-	5, 					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_TX_ENDPOINT | 0x80,		// bEndpointAddress
-	0x09, 					// bmAttributes = isochronous, adaptive
-	LSB(AUDIO_TX_SIZE), MSB(AUDIO_TX_SIZE),	// wMaxPacketSize
-	4,			 		// bInterval, 4 = every 8 micro-frames
-	0,					// bRefresh
-	0,					// bSynchAddress
+	9, 								// bLength
+	USB_DESC_TYPE_ENDPOINT,					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
+	AUDIO_TX_EP | AUDIO_EP_IN_MASK,     		// bEndpointAddress
+	AUDIO_EP_TYPE_ISOC | AUDIO_EP_TYPE_ADAPTIVE, 	// bmAttributes
+	// TODO(mcginty): above SHOULD be ASYNC, not ADAPTIVE
+	LSB(AUDIO_TX_SIZE), MSB(AUDIO_TX_SIZE),		// wMaxPacketSize
+	1,			 					// bInterval, must be set to 1
+	0,								// bRefresh TODO(mcginty): double-check on bRefresh
+	0,								// bSynchAddress
+
 	// Class-Specific AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
-	7,  					// bLength
-	0x25,  					// bDescriptorType, 0x25 = CS_ENDPOINT
-	1,  					// bDescriptorSubtype, 1 = EP_GENERAL
-	0x00,  					// bmAttributes
-	0,  					// bLockDelayUnits, 1 = ms
-	0x00, 0x00,  				// wLockDelay
+	7,					// bLength
+	CS_DESC_TYPE_ENDPOINT,		// bDescriptorType
+	CS_DESC_SUBTYPE_EP_GENERAL,	// bDescriptorSubtype, 1 = EP_GENERAL
+	0x00,					// bmAttributes (whether sample rate is controllable, etc.)
+	0x00,					// bLockDelayUnits, 0 = undefined, 1 = ms
+	0x00, 0x00,				// wLockDelay
+
 	// Standard AS Interface Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
 	// Alternate 0: default setting, disabled zero bandwidth
-	9,					// bLenght
-	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+2,			// bInterfaceNumber
+	//
+	// This is for the INPUT capabilities (DEVICE => HOST)
+	//
+	// This descriptor needs to have two "alternate settings"
+	// 0: the default setting, "disabled mode", zero bandwidth, no endpoints
+	// 1: the "active" setting, full streaming endpoint
+	9,					// bLength
+	USB_DESC_TYPE_INTERFACE,	// bDescriptorType = INTERFACE
+	AUDIO_INTERFACE+2,		// bInterfaceNumber
 	0,					// bAlternateSetting
 	0,					// bNumEndpoints
 	1,					// bInterfaceClass, 1 = AUDIO
@@ -1557,62 +1621,68 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0,					// bInterfaceProtocol
 	0,					// iInterface
 	// Alternate 1: streaming data
-	9,					// bLenght
-	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+2,			// bInterfaceNumber
+	9,					// bLength
+	USB_DESC_TYPE_INTERFACE,	// bDescriptorType = INTERFACE
+	AUDIO_INTERFACE+2,		// bInterfaceNumber
 	1,					// bAlternateSetting
 	2,					// bNumEndpoints
 	1,					// bInterfaceClass, 1 = AUDIO
 	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
 	0,					// bInterfaceProtocol
 	0,					// iInterface
+
 	// Class-Specific AS Interface Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
 	7, 					// bLength
-	0x24,					// bDescriptorType = CS_INTERFACE
-	1,					// bDescriptorSubtype, 1 = AS_GENERAL
-	3,					// bTerminalLink: Terminal ID = 3
+	CS_DESC_TYPE_INTERFACE,		// bDescriptorType = CS_INTERFACE
+	CS_DESC_SUBTYPE_AS_GENERAL,	// bDescriptorSubtype, 1 = AS_GENERAL
+	3,					// bTerminalLink: Terminal ID = 3 (USB_STREAMING Input Terminal)
 	3,					// bDelay (approx 3ms delay, audio lib updates)
 	0x01, 0x00,				// wFormatTag, 0x0001 = PCM
+
 	// Type I Format Descriptor
 	// USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
 	11,					// bLength
-	0x24,					// bDescriptorType = CS_INTERFACE
-	2,					// bDescriptorSubtype = FORMAT_TYPE
-	1,					// bFormatType = FORMAT_TYPE_I
-	AUDIO_CHANNELS,					// bNrChannels = 2
-	AUDIO_SAMPLE_BYTES,					// bSubFrameSize = 2 byte
-	AUDIO_BIT_DEPTH,					// bBitResolution = 16 bits
+	CS_DESC_TYPE_INTERFACE,		// bDescriptorType = CS_INTERFACE
+	CS_DESC_SUBTYPE_FORMAT,		// bDescriptorSubtype = FORMAT_TYPE
+	AUDIO_FORMAT_TYPE_I,		// bFormatType = FORMAT_TYPE_I
+	AUDIO_CHANNELS,			// bNrChannels
+	AUDIO_SAMPLE_BYTES,		// bSubFrameSize
+	AUDIO_BIT_DEPTH,			// bBitResolution
 	1,					// bSamFreqType = 1 frequency
 	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
+
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
-	5, 					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_RX_ENDPOINT,			// bEndpointAddress
-	0x05, 					// bmAttributes = isochronous, asynchronous
+	USB_DESC_TYPE_ENDPOINT, 	// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
+	AUDIO_RX_EP,			// bEndpointAddress
+	AUDIO_EP_TYPE_ISOC | AUDIO_EP_TYPE_ASYNC, // bmAttributes = isochronous, asynchronous
 	LSB(AUDIO_RX_SIZE), MSB(AUDIO_RX_SIZE),	// wMaxPacketSize
-	4,			 		// bInterval, 4 = every 8 micro-frames
-	0,					// bRefresh
-	AUDIO_SYNC_ENDPOINT | 0x80,		// bSynchAddress
+	0x01,			 		// bInterval
+	0x00,					// bRefresh
+	AUDIO_SYNC_ENDPOINT | AUDIO_EP_IN_MASK,	// bSynchAddress
+
 	// Class-Specific AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
 	7,  					// bLength
-	0x25,  					// bDescriptorType, 0x25 = CS_ENDPOINT
-	1,  					// bDescriptorSubtype, 1 = EP_GENERAL
-	0x00,  					// bmAttributes
-	0,  					// bLockDelayUnits, 1 = ms
-	0x00, 0x00,  				// wLockDelay
+	CS_DESC_TYPE_ENDPOINT,  	// bDescriptorType, 0x25 = CS_ENDPOINT
+	CS_DESC_SUBTYPE_EP_GENERAL,  	// bDescriptorSubtype, 1 = EP_GENERAL
+	0x00,  				// bmAttributes (eg. sampling frequency control = 0x01)
+	0x00,  				// bLockDelayUnits, 0 = undefined, 1 = ms
+	0x00, 0x00,  			// wLockDelay
+
 	// Standard AS Isochronous Audio Synch Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.2.1, Table 4-22, page 63-64
 	9, 					// bLength
-	5, 					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_SYNC_ENDPOINT | 0x80,		// bEndpointAddress
-	0x11, 					// bmAttributes = isochronous, feedback
-	4, 0,					// wMaxPacketSize, 4 bytes
-	4,			 		// bInterval, 4 = 4 = every 8 micro-frames
-	7,					// bRefresh,
-	0,					// bSynchAddress
+	USB_DESC_TYPE_ENDPOINT,		// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
+	AUDIO_SYNC_ENDPOINT | AUDIO_EP_IN_MASK,	// bEndpointAddress
+	0x11, 				// bmAttributes = isochronous, feedback
+	0x04, 0x00,				// wMaxPacketSize, 4 bytes
+	0x01,			 		// bInterval, must be set to 1
+	0x07,					// bRefresh, rate of feedback, as power of 2, eg. 2^7 = 128ms
+	// TODO(jake): do we want a 128ms feedback here?
+	0x00,					// bSynchAddress
 #endif
 
 #ifdef MULTITOUCH_INTERFACE
@@ -2524,11 +2594,11 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	// Class-Specific AS Interface Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
 	7, 					// bLength
-	0x24,					// bDescriptorType = CS_INTERFACE
+	0x24,				// bDescriptorType = CS_INTERFACE
 	1,					// bDescriptorSubtype, 1 = AS_GENERAL
 	2,					// bTerminalLink: Terminal ID = 2
 	3,					// bDelay (approx 3ms delay, audio lib updates)
-	0x01, 0x00,				// wFormatTag, 0x0001 = PCM
+	0x01, 0x00,			// wFormatTag, 0x0001 = PCM
 	// Type I Format Descriptor
 	// USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
 	11,					// bLength
@@ -2544,7 +2614,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
 	5, 					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_TX_ENDPOINT | 0x80,		// bEndpointAddress
+	AUDIO_TX_EP | 0x80,		// bEndpointAddress
 	0x09, 					// bmAttributes = isochronous, adaptive
 	LSB(AUDIO_TX_SIZE), MSB(AUDIO_TX_SIZE),	// wMaxPacketSize
 	1,			 		// bInterval, 1 = every frame

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -1399,290 +1399,290 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 #define AUDIO_CONTROL_MUTE 0x01
 #define AUDIO_CONTROL_VOL 0x02
 
-	// configuration for 480 Mbit/sec speed
-	// IAD (interface association descriptor), USB ECN, Table 9-Z
-	// USB IAD allows the device to group interfaces that belong to a function.
-	// NOTE(mcginty): This seems to be used as the Teensy also has an HID function.
-	8,			// bLength
-	11,			// bDescriptorType
-	AUDIO_INTERFACE,	// bFirstInterface
-	3,			// bInterfaceCount
-	0x01,			// bFunctionClass, 0x01 = AUDIO
-	0x01,			// bFunctionSubClass
-	0x00,			// bFunctionProtocol
-	0,			// iFunction
+      // configuration for 480 Mbit/sec speed
+      // IAD (interface association descriptor), USB ECN, Table 9-Z
+      // USB IAD allows the device to group interfaces that belong to a function.
+      // NOTE(mcginty): This seems to be used as the Teensy also has an HID function.
+      8,                    // bLength
+      11,                   // bDescriptorType
+      AUDIO_INTERFACE,      // bFirstInterface
+      3,                    // bInterfaceCount
+      0x01,                 // bFunctionClass, 0x01 = AUDIO
+      0x01,                 // bFunctionSubClass
+      0x00,                 // bFunctionProtocol
+      0,                    // iFunction
 
-	// Standard AudioControl (AC) Interface Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-1, page 36
-	9,					// bLength
-	4,					// bDescriptorType, 4 = INTERFACE
-	AUDIO_INTERFACE,			// bInterfaceNumber
-	0,					// bAlternateSetting
-	0,					// bNumEndpoints: 0  for the default, 1 if the optional status interrupt endpoint is present.
-	1,					// bInterfaceClass, 1 = AUDIO
-	1,					// bInterfaceSubclass, 1 = AUDIO_CONTROL
-	0,					// bInterfaceProtocol, unused (must be 0)
-	0,					// iInterface, optional index of a string descriptor that describes this interface.
+      // Standard AudioControl (AC) Interface Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-1, page 36
+      9,                    // bLength
+      4,                    // bDescriptorType, 4 = INTERFACE
+      AUDIO_INTERFACE,      // bInterfaceNumber
+      0,                    // bAlternateSetting
+      0,                    // bNumEndpoints: 0  for the default, 1 if the optional status interrupt endpoint is present.
+      1,                    // bInterfaceClass, 1 = AUDIO
+      1,                    // bInterfaceSubclass, 1 = AUDIO_CONTROL
+      0,                    // bInterfaceProtocol, unused (must be 0)
+      0,                    // iInterface, optional index of a string descriptor that describes this interface.
 
-	// Class-specific AC Interface Header Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-2, page 37-38
-	// Followed by one or more unit and/or terminal descriptors (UD and TD, respectively).
-	10,				// bLength
-	0x24,				// bDescriptorType, 0x24 = CS_INTERFACE
-	0x01,				// bDescriptorSubtype, 1 = HEADER
-	0x00, 0x01,			// bcdADC (USB Audio Class v1.0)
-	LSB(62), MSB(62),		// wTotalLength
-	2,				// bInCollection
-	AUDIO_INTERFACE+1,	// baInterfaceNr(1) - Transmit to PC
-	AUDIO_INTERFACE+2,	// baInterfaceNr(2) - Receive from PC
+      // Class-specific AC Interface Header Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-2, page 37-38
+      // Followed by one or more unit and/or terminal descriptors (UD and TD, respectively).
+      10,                   // bLength
+      0x24,                 // bDescriptorType, 0x24 = CS_INTERFACE
+      0x01,                 // bDescriptorSubtype, 1 = HEADER
+      0x00, 0x01,           // bcdADC (USB Audio Class v1.0)
+      LSB(62), MSB(62),     // wTotalLength
+      2,                    // bInCollection
+      AUDIO_INTERFACE+1,    // baInterfaceNr(1) - Transmit to PC
+      AUDIO_INTERFACE+2,    // baInterfaceNr(2) - Receive from PC
 
-	// Input Terminal Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-3, page 39
-	//
-	// "External" terminal descriptor:
-	// This optional descriptor serves as a "documentation" terminal to let the host
-	// know that it should treat this terminal as a generic Digital Audio terminal, as opposed to
-	// an analog line connector, for example.
-	//
-	// See USB DCD for Terminal Types: https://www.usb.org/sites/default/files/termt10.pdf
-	12,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	0x02,					// bDescriptorSubType, 2 = INPUT_TERMINAL
-	1,					// bTerminalID (0x00 is reserved and invalid)
-	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
-	0,					// bAssocTerminal, 0 = unidirectional
-	AUDIO_CHANNELS,			// bNrChannels 
-	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
-	// TODO(mcginty): should the above 2 fields always be the sameas the other channel configs?
-	0,					// iChannelNames
-	0,					// iTerminal, optional string descriptor
+      // Input Terminal Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-3, page 39
+      //
+      // "External" terminal descriptor:
+      // This optional descriptor serves as a "documentation" terminal to let the host
+      // know that it should treat this terminal as a generic Digital Audio terminal, as opposed to
+      // an analog line connector, for example.
+      //
+      // See USB DCD for Terminal Types: https://www.usb.org/sites/default/files/termt10.pdf
+      12,                   // bLength
+      0x24,                 // bDescriptorType, 0x24 = CS_INTERFACE
+      0x02,                 // bDescriptorSubType, 2 = INPUT_TERMINAL
+      1,                    // bTerminalID (0x00 is reserved and invalid)
+      0x02, 0x06,           // wTerminalType, 0x0602 = Digital Audio
+      0,                    // bAssocTerminal, 0 = unidirectional
+      AUDIO_CHANNELS,       // bNrChannels 
+      0x03, 0x00,           // wChannelConfig, 0x0003 = Left & Right Front
+      // TODO(mcginty): should the above 2 fields always be the sameas the other channel configs?
+      0,                    // iChannelNames
+      0,                    // iTerminal, optional string descriptor
 
-	// Output Terminal Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-4, page 40
-	// This terminal is connected to the AudioStreaming interface.
-	9,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	3,					// bDescriptorSubtype, 3 = OUTPUT_TERMINAL
-	2,					// bTerminalID
-	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
-	0,					// bAssocTerminal, 0 = unidirectional
-	1,					// bCSourceID, connected to input terminal, ID=1
-	0,					// iTerminal, optional string descriptor
+      // Output Terminal Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-4, page 40
+      // This terminal is connected to the AudioStreaming interface.
+      9,                    // bLength
+      0x24,                 // bDescriptorType, 0x24 = CS_INTERFACE
+      3,                    // bDescriptorSubtype, 3 = OUTPUT_TERMINAL
+      2,                    // bTerminalID
+      0x01, 0x01,           // wTerminalType, 0x0101 = USB_STREAMING
+      0,                    // bAssocTerminal, 0 = unidirectional
+      1,                    // bCSourceID, connected to input terminal, ID=1
+      0,                    // iTerminal, optional string descriptor
 
-	// Input Terminal Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-3, page 39
-	// This terminal is connected to the AudioStreaming interface.
-	12,				// bLength
-	0x24,				// bDescriptorType, 0x24 = CS_INTERFACE
-	2,				// bDescriptorSubType, 2 = INPUT_TERMINAL
-	3,				// bTerminalID
-	0x01, 0x01,			// wTerminalType, 0x0101 = USB_STREAMING
-	0,				// bAssocTerminal, 0 = unidirectional
-	AUDIO_CHANNELS,		// bNrChannels
-	0x03, 0x00,			// wChannelConfig, 0x0003 = Left & Right Front
-	0,				// iChannelNames
-	0,				// iTerminal, optional string descriptor
+      // Input Terminal Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-3, page 39
+      // This terminal is connected to the AudioStreaming interface.
+      12,                   // bLength
+      0x24,                 // bDescriptorType, 0x24 = CS_INTERFACE
+      2,                    // bDescriptorSubType, 2 = INPUT_TERMINAL
+      3,                    // bTerminalID
+      0x01, 0x01,           // wTerminalType, 0x0101 = USB_STREAMING
+      0,                    // bAssocTerminal, 0 = unidirectional
+      AUDIO_CHANNELS,       // bNrChannels
+      0x03, 0x00,           // wChannelConfig, 0x0003 = Left & Right Front
+      0,                    // iChannelNames
+      0,                    // iTerminal, optional string descriptor
 
-	// Feature Unit Descriptor (Volume)
-	10,				// bLength
-	0x24,				// bDescriptorType = CS_INTERFACE
-	0x06,				// bDescriptorSubType = FEATURE_UNIT
-	0x31,				// bUnitID TODO(mcginty): why 0x31?
-	0x03,				// bSourceID (Input Terminal)
-	0x01,				// bControlSize (each channel is 1 byte, 3 channels)
-	AUDIO_CONTROL_MUTE,	// bmaControls(0) Master: Mute
-	AUDIO_CONTROL_VOL,	// bmaControls(1) Left: Volume TODO(mcginty): remove?
-	AUDIO_CONTROL_VOL,	// bmaControls(2) Right: Volume TODO(mcginty): remove?
-	0x00,				// iFeature, optional string descriptor
+      // Feature Unit Descriptor (Volume)
+      10,                   // bLength
+      0x24,                 // bDescriptorType = CS_INTERFACE
+      0x06,                 // bDescriptorSubType = FEATURE_UNIT
+      0x31,                 // bUnitID TODO(mcginty): why 0x31?
+      0x03,                 // bSourceID (Input Terminal)
+      0x01,                 // bControlSize (each channel is 1 byte, 3 channels)
+      AUDIO_CONTROL_MUTE,   // bmaControls(0) Master: Mute
+      AUDIO_CONTROL_VOL,    // bmaControls(1) Left: Volume TODO(mcginty): remove?
+      AUDIO_CONTROL_VOL,    // bmaControls(2) Right: Volume TODO(mcginty): remove?
+      0x00,                 // iFeature, optional string descriptor
 
-	// Output Terminal Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-4, page 40
-	//
-	// "External" terminal descriptor:
-	// This optional descriptor serves as a "documentation" terminal to let the host
-	// know that it should treat this terminal as a generic Digital Audio terminal, as opposed to
-	// an analog line connector, for example.
-	//
-	// See USB DCD for Terminal Types: https://www.usb.org/sites/default/files/termt10.pdf
-	9,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	3,					// bDescriptorSubtype, 3 = OUTPUT_TERMINAL
-	4,					// bTerminalID
-	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
-	0,					// bAssocTerminal, 0 = unidirectional
-	0x31,				      // bCSourceID, connected to feature, ID=31
-	0,					// iTerminal, optional string descriptor
+      // Output Terminal Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-4, page 40
+      //
+      // "External" terminal descriptor:
+      // This optional descriptor serves as a "documentation" terminal to let the host
+      // know that it should treat this terminal as a generic Digital Audio terminal, as opposed to
+      // an analog line connector, for example.
+      //
+      // See USB DCD for Terminal Types: https://www.usb.org/sites/default/files/termt10.pdf
+      9,                    // bLength
+      0x24,                 // bDescriptorType, 0x24 = CS_INTERFACE
+      3,                    // bDescriptorSubtype, 3 = OUTPUT_TERMINAL
+      4,                    // bTerminalID
+      0x02, 0x06,           // wTerminalType, 0x0602 = Digital Audio
+      0,                    // bAssocTerminal, 0 = unidirectional
+      0x31,                 // bCSourceID, connected to feature, ID=31
+      0,                    // iTerminal, optional string descriptor
 
-	// Standard AS (AudioStreaming) Interface Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
-	// Alternate 0: default setting, disabled zero bandwidth
-	//
-	// This is for the OUTPUT capabilities (HOST => DEVICE)
-	//
-	// This descriptor needs to have two "alternate settings"
-	// 0: the default setting, "disabled mode", zero bandwidth, no endpoints
-	// 1: the "active" setting, full streaming endpoint
-	9,					// bLenght
-	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+1,		// bInterfaceNumber
-	0,					// bAlternateSetting
-	0,					// bNumEndpoints
-	1,					// bInterfaceClass, 1 = AUDIO
-	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
-	0,					// bInterfaceProtocol
-	0,					// iInterface
-	// Alternate 1: streaming data
-	9,					// bLenght
-	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+1,		// bInterfaceNumber
-	1,					// bAlternateSetting
-	1,					// bNumEndpoints
-	1,					// bInterfaceClass, 1 = AUDIO
-	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
-	0,					// bInterfaceProtocol
-	0,					// iInterface
+      // Standard AS (AudioStreaming) Interface Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
+      // Alternate 0: default setting, disabled zero bandwidth
+      //
+      // This is for the OUTPUT capabilities (HOST => DEVICE)
+      //
+      // This descriptor needs to have two "alternate settings"
+      // 0: the default setting, "disabled mode", zero bandwidth, no endpoints
+      // 1: the "active" setting, full streaming endpoint
+      9,                    // bLength
+      4,                    // bDescriptorType = INTERFACE
+      AUDIO_INTERFACE+1,    // bInterfaceNumber
+      0,                    // bAlternateSetting
+      0,                    // bNumEndpoints
+      1,                    // bInterfaceClass, 1 = AUDIO
+      2,                    // bInterfaceSubclass, 2 = AUDIO_STREAMING
+      0,                    // bInterfaceProtocol
+      0,                    // iInterface
+      // Alternate 1: streaming data
+      9,                    // bLength
+      4,                    // bDescriptorType = INTERFACE
+      AUDIO_INTERFACE+1,    // bInterfaceNumber
+      1,                    // bAlternateSetting
+      1,                    // bNumEndpoints
+      1,                    // bInterfaceClass, 1 = AUDIO
+      2,                    // bInterfaceSubclass, 2 = AUDIO_STREAMING
+      0,                    // bInterfaceProtocol
+      0,                    // iInterface
 
-	// Class-Specific AS Interface Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
-	//
-	// This is for the OUTPUT streaming (HOST => DEVICE)
-	7, 					// bLength
-	0x24,					// bDescriptorType = CS_INTERFACE
-	1,					// bDescriptorSubtype, 1 = AS_GENERAL
-	2,					// bTerminalLink: Terminal ID = 2 (USB_STREAMING Output Terminal)
-	3,					// bDelay (approx 3ms delay, audio lib updates)
-	// TODO(mcginty): ^ what is this 3ms from?
-	0x01, 0x00,				// wFormatTag, 0x0001 = PCM
+      // Class-Specific AS Interface Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
+      //
+      // This is for the OUTPUT streaming (HOST => DEVICE)
+      7,                    // bLength
+      0x24,                 // bDescriptorType = CS_INTERFACE
+      1,                    // bDescriptorSubtype, 1 = AS_GENERAL
+      2,                    // bTerminalLink: Terminal ID = 2 (USB_STREAMING Output Terminal)
+      3,                    // bDelay (approx 3ms delay, audio lib updates)
+      // TODO(mcginty): ^ what is this 3ms from?
+      0x01, 0x00,           // wFormatTag, 0x0001 = PCM
 
-	#define AUDIO_FORMAT_TYPE_I 0x01
-	#define USB_DESC_TYPE_INTERFACE 0x04
-	#define USB_DESC_TYPE_ENDPOINT 0x05
+      #define AUDIO_FORMAT_TYPE_I 0x01
+      #define USB_DESC_TYPE_INTERFACE 0x04
+      #define USB_DESC_TYPE_ENDPOINT 0x05
 
-	#define CS_DESC_TYPE_INTERFACE 0x24
-	#define CS_DESC_TYPE_ENDPOINT 0x25
-	#define CS_DESC_SUBTYPE_FORMAT 0x02
-	#define CS_DESC_SUBTYPE_EP_GENERAL 0x01
-	#define CS_DESC_SUBTYPE_AS_GENERAL 0x01
+      #define CS_DESC_TYPE_INTERFACE 0x24
+      #define CS_DESC_TYPE_ENDPOINT 0x25
+      #define CS_DESC_SUBTYPE_FORMAT 0x02
+      #define CS_DESC_SUBTYPE_EP_GENERAL 0x01
+      #define CS_DESC_SUBTYPE_AS_GENERAL 0x01
 
-	#define AUDIO_EP_IN_MASK 0x80 // A mask used to indicate a specified endpoint ID is an input
-	#define AUDIO_EP_TYPE_ISOC 0x01 // Isochronous Endpoint Type
-	#define AUDIO_EP_TYPE_ADAPTIVE 0x08 // Isochronous Endpoint Type
-	#define AUDIO_EP_TYPE_ASYNC 0x04 // Isochronous Endpoint Type
-	// Type I Format Descriptor
-	// USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
-	// See: https://usb.org/sites/default/files/frmts10.pdf
-	11,					// bLength
-	CS_DESC_TYPE_INTERFACE,		// bDescriptorType = CS_INTERFACE
-	CS_DESC_SUBTYPE_FORMAT,		// bDescriptorSubtype = FORMAT_TYPE
-	AUDIO_FORMAT_TYPE_I,		// bFormatType
-	AUDIO_CHANNELS,			// bNrChannels
-	AUDIO_SAMPLE_BYTES,		// bSubFrameSize (in bytes)
-	AUDIO_BIT_DEPTH,			// bBitResolution
-	1,					// bSamFreqType (number of frequencies supported)
-	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
+      #define AUDIO_EP_IN_MASK 0x80 // A mask used to indicate a specified endpoint ID is an input
+      #define AUDIO_EP_TYPE_ISOC 0x01 // Isochronous Endpoint Type
+      #define AUDIO_EP_TYPE_ADAPTIVE 0x08 // Isochronous Endpoint Type
+      #define AUDIO_EP_TYPE_ASYNC 0x04 // Isochronous Endpoint Type
+      // Type I Format Descriptor
+      // USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
+      // See: https://usb.org/sites/default/files/frmts10.pdf
+      11,                                           // bLength
+      CS_DESC_TYPE_INTERFACE,                       // bDescriptorType = CS_INTERFACE
+      CS_DESC_SUBTYPE_FORMAT,                       // bDescriptorSubtype = FORMAT_TYPE
+      AUDIO_FORMAT_TYPE_I,                          // bFormatType
+      AUDIO_CHANNELS,                               // bNrChannels
+      AUDIO_SAMPLE_BYTES,                           // bSubFrameSize (in bytes)
+      AUDIO_BIT_DEPTH,                              // bBitResolution
+      1,                                            // bSamFreqType (number of frequencies supported)
+      AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),     // tSamFreq
 
-	// Standard AS Isochronous Audio Data Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
-	9, 								// bLength
-	USB_DESC_TYPE_ENDPOINT,					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_TX_EP | AUDIO_EP_IN_MASK,     		// bEndpointAddress
-	AUDIO_EP_TYPE_ISOC | AUDIO_EP_TYPE_ADAPTIVE, 	// bmAttributes
-	// TODO(mcginty): above SHOULD be ASYNC, not ADAPTIVE
-	LSB(AUDIO_TX_SIZE), MSB(AUDIO_TX_SIZE),		// wMaxPacketSize
-	1,			 					// bInterval, must be set to 1
-	0,								// bRefresh TODO(mcginty): double-check on bRefresh
-	0,								// bSynchAddress
+      // Standard AS Isochronous Audio Data Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
+      9,                                            // bLength
+      USB_DESC_TYPE_ENDPOINT,                       // bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
+      AUDIO_TX_EP | AUDIO_EP_IN_MASK,               // bEndpointAddress
+      AUDIO_EP_TYPE_ISOC | AUDIO_EP_TYPE_ADAPTIVE,  // bmAttributes
+      // TODO(mcginty): above SHOULD be ASYNC, not ADAPTIVE
+      LSB(AUDIO_TX_SIZE), MSB(AUDIO_TX_SIZE),       // wMaxPacketSize
+      1,                                            // bInterval, must be set to 1
+      0,                                            // bRefresh TODO(mcginty): double-check on bRefresh
+      0,                                            // bSynchAddress
 
-	// Class-Specific AS Isochronous Audio Data Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
-	7,					// bLength
-	CS_DESC_TYPE_ENDPOINT,		// bDescriptorType
-	CS_DESC_SUBTYPE_EP_GENERAL,	// bDescriptorSubtype, 1 = EP_GENERAL
-	0x00,					// bmAttributes (whether sample rate is controllable, etc.)
-	0x00,					// bLockDelayUnits, 0 = undefined, 1 = ms
-	0x00, 0x00,				// wLockDelay
+      // Class-Specific AS Isochronous Audio Data Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
+      7,                                            // bLength
+      CS_DESC_TYPE_ENDPOINT,                        // bDescriptorType
+      CS_DESC_SUBTYPE_EP_GENERAL,                   // bDescriptorSubtype, 1 = EP_GENERAL
+      0x00,                                         // bmAttributes (whether sample rate is controllable, etc.)
+      0x00,                                         // bLockDelayUnits, 0 = undefined, 1 = ms
+      0x00, 0x00,                                   // wLockDelay
 
-	// Standard AS Interface Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
-	// Alternate 0: default setting, disabled zero bandwidth
-	//
-	// This is for the INPUT capabilities (DEVICE => HOST)
-	//
-	// This descriptor needs to have two "alternate settings"
-	// 0: the default setting, "disabled mode", zero bandwidth, no endpoints
-	// 1: the "active" setting, full streaming endpoint
-	9,					// bLength
-	USB_DESC_TYPE_INTERFACE,	// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+2,		// bInterfaceNumber
-	0,					// bAlternateSetting
-	0,					// bNumEndpoints
-	1,					// bInterfaceClass, 1 = AUDIO
-	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
-	0,					// bInterfaceProtocol
-	0,					// iInterface
-	// Alternate 1: streaming data
-	9,					// bLength
-	USB_DESC_TYPE_INTERFACE,	// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+2,		// bInterfaceNumber
-	1,					// bAlternateSetting
-	2,					// bNumEndpoints
-	1,					// bInterfaceClass, 1 = AUDIO
-	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
-	0,					// bInterfaceProtocol
-	0,					// iInterface
+      // Standard AS Interface Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
+      // Alternate 0: default setting, disabled zero bandwidth
+      //
+      // This is for the INPUT capabilities (DEVICE => HOST)
+      //
+      // This descriptor needs to have two "alternate settings"
+      // 0: the default setting, "disabled mode", zero bandwidth, no endpoints
+      // 1: the "active" setting, full streaming endpoint
+      9,                                // bLength
+      USB_DESC_TYPE_INTERFACE,          // bDescriptorType = INTERFACE
+      AUDIO_INTERFACE+2,                // bInterfaceNumber
+      0,                                // bAlternateSetting
+      0,                                // bNumEndpoints
+      1,                                // bInterfaceClass, 1 = AUDIO
+      2,                                // bInterfaceSubclass, 2 = AUDIO_STREAMING
+      0,                                // bInterfaceProtocol
+      0,                                // iInterface
+      // Alternate 1: streaming data
+      9,                                // bLength
+      USB_DESC_TYPE_INTERFACE,          // bDescriptorType = INTERFACE
+      AUDIO_INTERFACE+2,                // bInterfaceNumber
+      1,                                // bAlternateSetting
+      2,                                // bNumEndpoints
+      1,                                // bInterfaceClass, 1 = AUDIO
+      2,                                // bInterfaceSubclass, 2 = AUDIO_STREAMING
+      0,                                // bInterfaceProtocol
+      0,                                // iInterface
 
-	// Class-Specific AS Interface Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
-	7, 					// bLength
-	CS_DESC_TYPE_INTERFACE,		// bDescriptorType = CS_INTERFACE
-	CS_DESC_SUBTYPE_AS_GENERAL,	// bDescriptorSubtype, 1 = AS_GENERAL
-	3,					// bTerminalLink: Terminal ID = 3 (USB_STREAMING Input Terminal)
-	3,					// bDelay (approx 3ms delay, audio lib updates)
-	0x01, 0x00,				// wFormatTag, 0x0001 = PCM
+      // Class-Specific AS Interface Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
+      7,                                // bLength
+      CS_DESC_TYPE_INTERFACE,           // bDescriptorType = CS_INTERFACE
+      CS_DESC_SUBTYPE_AS_GENERAL,       // bDescriptorSubtype, 1 = AS_GENERAL
+      3,                                // bTerminalLink: Terminal ID = 3 (USB_STREAMING Input Terminal)
+      3,                                // bDelay (approx 3ms delay, audio lib updates)
+      0x01, 0x00,                       // wFormatTag, 0x0001 = PCM
 
-	// Type I Format Descriptor
-	// USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
-	11,					// bLength
-	CS_DESC_TYPE_INTERFACE,		// bDescriptorType = CS_INTERFACE
-	CS_DESC_SUBTYPE_FORMAT,		// bDescriptorSubtype = FORMAT_TYPE
-	AUDIO_FORMAT_TYPE_I,		// bFormatType = FORMAT_TYPE_I
-	AUDIO_CHANNELS,			// bNrChannels
-	AUDIO_SAMPLE_BYTES,		// bSubFrameSize
-	AUDIO_BIT_DEPTH,			// bBitResolution
-	1,					// bSamFreqType = 1 frequency
-	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
+      // Type I Format Descriptor
+      // USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
+      11,                                       // bLength
+      CS_DESC_TYPE_INTERFACE,                   // bDescriptorType = CS_INTERFACE
+      CS_DESC_SUBTYPE_FORMAT,                   // bDescriptorSubtype = FORMAT_TYPE
+      AUDIO_FORMAT_TYPE_I,                      // bFormatType = FORMAT_TYPE_I
+      AUDIO_CHANNELS,                           // bNrChannels
+      AUDIO_SAMPLE_BYTES,                       // bSubFrameSize
+      AUDIO_BIT_DEPTH,                          // bBitResolution
+      1,                                        // bSamFreqType = 1 frequency
+      AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY), // tSamFreq
 
-	// Standard AS Isochronous Audio Data Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
-	9, 					// bLength
-	USB_DESC_TYPE_ENDPOINT, 	// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_RX_EP,			// bEndpointAddress
-	AUDIO_EP_TYPE_ISOC | AUDIO_EP_TYPE_ASYNC, // bmAttributes = isochronous, asynchronous
-	LSB(AUDIO_RX_SIZE), MSB(AUDIO_RX_SIZE),	// wMaxPacketSize
-	0x01,			 		// bInterval
-	0x00,					// bRefresh
-	AUDIO_SYNC_ENDPOINT | AUDIO_EP_IN_MASK,	// bSynchAddress
+      // Standard AS Isochronous Audio Data Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
+      9,                                        // bLength
+      USB_DESC_TYPE_ENDPOINT,                   // bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
+      AUDIO_RX_EP,                              // bEndpointAddress
+      AUDIO_EP_TYPE_ISOC | AUDIO_EP_TYPE_ASYNC, // bmAttributes = isochronous, asynchronous
+      LSB(AUDIO_RX_SIZE), MSB(AUDIO_RX_SIZE),   // wMaxPacketSize
+      0x01,                                     // bInterval
+      0x00,                                     // bRefresh
+      AUDIO_SYNC_ENDPOINT | AUDIO_EP_IN_MASK,   // bSynchAddress
 
-	// Class-Specific AS Isochronous Audio Data Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
-	7,  					// bLength
-	CS_DESC_TYPE_ENDPOINT,  	// bDescriptorType, 0x25 = CS_ENDPOINT
-	CS_DESC_SUBTYPE_EP_GENERAL,  	// bDescriptorSubtype, 1 = EP_GENERAL
-	0x00,  				// bmAttributes (eg. sampling frequency control = 0x01)
-	0x00,  				// bLockDelayUnits, 0 = undefined, 1 = ms
-	0x00, 0x00,  			// wLockDelay
+      // Class-Specific AS Isochronous Audio Data Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
+      7,                                // bLength
+      CS_DESC_TYPE_ENDPOINT,            // bDescriptorType, 0x25 = CS_ENDPOINT
+      CS_DESC_SUBTYPE_EP_GENERAL,       // bDescriptorSubtype, 1 = EP_GENERAL
+      0x00,                             // bmAttributes (eg. sampling frequency control = 0x01)
+      0x00,                             // bLockDelayUnits, 0 = undefined, 1 = ms
+      0x00, 0x00,                       // wLockDelay
 
-	// Standard AS Isochronous Audio Synch Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.2.1, Table 4-22, page 63-64
-	9, 					// bLength
-	USB_DESC_TYPE_ENDPOINT,		// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_SYNC_ENDPOINT | AUDIO_EP_IN_MASK,	// bEndpointAddress
-	0x11, 				// bmAttributes = isochronous, feedback
-	0x04, 0x00,				// wMaxPacketSize, 4 bytes
-	0x01,			 		// bInterval, must be set to 1
-	0x07,					// bRefresh, rate of feedback, as power of 2, eg. 2^7 = 128ms
-	// TODO(jake): do we want a 128ms feedback here?
-	0x00,					// bSynchAddress
+      // Standard AS Isochronous Audio Synch Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.2.1, Table 4-22, page 63-64
+      9,                                        // bLength
+      USB_DESC_TYPE_ENDPOINT,                   // bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
+      AUDIO_SYNC_ENDPOINT | AUDIO_EP_IN_MASK,   // bEndpointAddress
+      0x11,                                     // bmAttributes = isochronous, feedback
+      0x04, 0x00,                               // wMaxPacketSize, 4 bytes
+      0x01,                                     // bInterval, must be set to 1
+      0x07,                                     // bRefresh, rate of feedback, as power of 2, eg. 2^7 = 128ms
+      // TODO(jake): do we want a 128ms feedback here?
+      0x00,                                     // bSynchAddress
 #endif
 
 #ifdef MULTITOUCH_INTERFACE

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -2492,211 +2492,211 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
         0,                                      // iFunction
 	// Standard AudioControl (AC) Interface Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-1, page 36
-	9,					// bLength
-	4,					// bDescriptorType, 4 = INTERFACE
-	AUDIO_INTERFACE,			// bInterfaceNumber
-	0,					// bAlternateSetting
-	0,					// bNumEndpoints
-	1,					// bInterfaceClass, 1 = AUDIO
-	1,					// bInterfaceSubclass, 1 = AUDIO_CONTROL
-	0,					// bInterfaceProtocol
-	0,					// iInterface
-	// Class-specific AC Interface Header Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-2, page 37-38
-	10,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	0x01,					// bDescriptorSubtype, 1 = HEADER
-	0x00, 0x01,				// bcdADC (version 1.0)
-	LSB(62), MSB(62),			// wTotalLength
-	2,					// bInCollection
-	AUDIO_INTERFACE+1,			// baInterfaceNr(1) - Transmit to PC
-	AUDIO_INTERFACE+2,			// baInterfaceNr(2) - Receive from PC
-	// Input Terminal Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-3, page 39
-	12,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	0x02,					// bDescriptorSubType, 2 = INPUT_TERMINAL
-	1,					// bTerminalID
-	//0x01, 0x02,				// wTerminalType, 0x0201 = MICROPHONE
-	//0x03, 0x06,				// wTerminalType, 0x0603 = Line Connector
-	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
-	0,					// bAssocTerminal, 0 = unidirectional
-	AUDIO_CHANNELS,					// bNrChannels
-	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
-	0,					// iChannelNames
-	0, 					// iTerminal
-	// Output Terminal Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-4, page 40
-	9,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	3,					// bDescriptorSubtype, 3 = OUTPUT_TERMINAL
-	2,					// bTerminalID
-	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
-	0,					// bAssocTerminal, 0 = unidirectional
-	1,					// bCSourceID, connected to input terminal, ID=1
-	0,					// iTerminal
-	// Input Terminal Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-3, page 39
-	12,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	2,					// bDescriptorSubType, 2 = INPUT_TERMINAL
-	3,					// bTerminalID
-	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
-	0,					// bAssocTerminal, 0 = unidirectional
-	AUDIO_CHANNELS,					// bNrChannels
-	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
-	0,					// iChannelNames
-	0, 					// iTerminal
-	// Volume feature descriptor
-	10,					// bLength
-	0x24, 				// bDescriptorType = CS_INTERFACE
-	0x06, 				// bDescriptorSubType = FEATURE_UNIT
-	0x31, 				// bUnitID
-	0x03, 				// bSourceID (Input Terminal)
-	0x01, 				// bControlSize (each channel is 1 byte, 3 channels)
-	0x01, 				// bmaControls(0) Master: Mute
-	0x02, 				// bmaControls(1) Left: Volume
-	0x02, 				// bmaControls(2) Right: Volume
-	0x00,				// iFeature
-	// Output Terminal Descriptor
-	// USB DCD for Audio Devices 1.0, Table 4-4, page 40
-	9,					// bLength
-	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
-	3,					// bDescriptorSubtype, 3 = OUTPUT_TERMINAL
-	4,					// bTerminalID
-	//0x02, 0x03,				// wTerminalType, 0x0302 = Headphones
-	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
-	0,					// bAssocTerminal, 0 = unidirectional
-	0x31,				// bCSourceID, connected to feature, ID=31
-	0,					// iTerminal
-	// Standard AS Interface Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
-	// Alternate 0: default setting, disabled zero bandwidth
-	9,					// bLenght
-	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+1,			// bInterfaceNumber
-	0,					// bAlternateSetting
-	0,					// bNumEndpoints
-	1,					// bInterfaceClass, 1 = AUDIO
-	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
-	0,					// bInterfaceProtocol
-	0,					// iInterface
-	// Alternate 1: streaming data
-	9,					// bLenght
-	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+1,			// bInterfaceNumber
-	1,					// bAlternateSetting
-	1,					// bNumEndpoints
-	1,					// bInterfaceClass, 1 = AUDIO
-	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
-	0,					// bInterfaceProtocol
-	0,					// iInterface
-	// Class-Specific AS Interface Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
-	7, 					// bLength
-	0x24,				// bDescriptorType = CS_INTERFACE
-	1,					// bDescriptorSubtype, 1 = AS_GENERAL
-	2,					// bTerminalLink: Terminal ID = 2
-	3,					// bDelay (approx 3ms delay, audio lib updates)
-	0x01, 0x00,			// wFormatTag, 0x0001 = PCM
-	// Type I Format Descriptor
-	// USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
-	11,					// bLength
-	0x24,					// bDescriptorType = CS_INTERFACE
-	2,					// bDescriptorSubtype = FORMAT_TYPE
-	1,					// bFormatType = FORMAT_TYPE_I
-	AUDIO_CHANNELS,					// bNrChannels = 2
-	AUDIO_SAMPLE_BYTES,	// bSubFrameSize = 2 byte
-	AUDIO_BIT_DEPTH,	// bBitResolution = 16 bits
-	1,					// bSamFreqType = 1 frequency
-	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
-	// Standard AS Isochronous Audio Data Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
-	9, 					// bLength
-	5, 					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_TX_EP | 0x80,		// bEndpointAddress
-	0x09, 					// bmAttributes = isochronous, adaptive
-	LSB(AUDIO_TX_SIZE), MSB(AUDIO_TX_SIZE),	// wMaxPacketSize
-	1,			 		// bInterval, 1 = every frame
-	0,					// bRefresh
-	0,					// bSynchAddress
-	// Class-Specific AS Isochronous Audio Data Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
-	7,  					// bLength
-	0x25,  					// bDescriptorType, 0x25 = CS_ENDPOINT
-	1,  					// bDescriptorSubtype, 1 = EP_GENERAL
-	0x00,  					// bmAttributes
-	0,  					// bLockDelayUnits, 1 = ms
-	0x00, 0x00,  				// wLockDelay
-	// Standard AS Interface Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
-	// Alternate 0: default setting, disabled zero bandwidth
-	9,					// bLenght
-	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+2,			// bInterfaceNumber
-	0,					// bAlternateSetting
-	0,					// bNumEndpoints
-	1,					// bInterfaceClass, 1 = AUDIO
-	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
-	0,					// bInterfaceProtocol
-	0,					// iInterface
-	// Alternate 1: streaming data
-	9,					// bLenght
-	4,					// bDescriptorType = INTERFACE
-	AUDIO_INTERFACE+2,			// bInterfaceNumber
-	1,					// bAlternateSetting
-	2,					// bNumEndpoints
-	1,					// bInterfaceClass, 1 = AUDIO
-	2,					// bInterfaceSubclass, 2 = AUDIO_STREAMING
-	0,					// bInterfaceProtocol
-	0,					// iInterface
-	// Class-Specific AS Interface Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
-	7, 					// bLength
-	0x24,					// bDescriptorType = CS_INTERFACE
-	1,					// bDescriptorSubtype, 1 = AS_GENERAL
-	3,					// bTerminalLink: Terminal ID = 3
-	3,					// bDelay (approx 3ms delay, audio lib updates)
-	0x01, 0x00,				// wFormatTag, 0x0001 = PCM
-	// Type I Format Descriptor
-	// USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
-	11,					// bLength
-	0x24,					// bDescriptorType = CS_INTERFACE
-	2,					// bDescriptorSubtype = FORMAT_TYPE
-	1,					// bFormatType = FORMAT_TYPE_I
-	AUDIO_CHANNELS,					// bNrChannels = 2
-	AUDIO_SAMPLE_BYTES,	// bSubFrameSize = 2 byte
-	AUDIO_BIT_DEPTH,	// bBitResolution = 16 bits
-	1,					// bSamFreqType = 1 frequency
-	AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY),		// tSamFreq
-	// Standard AS Isochronous Audio Data Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
-	9, 					// bLength
-	5, 					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_RX_ENDPOINT,			// bEndpointAddress
-	0x05, 					// bmAttributes = isochronous, asynchronous
-	LSB(AUDIO_RX_SIZE), MSB(AUDIO_RX_SIZE),	// wMaxPacketSize
-	1,			 		// bInterval, 1 = every frame
-	0,					// bRefresh
-	AUDIO_SYNC_ENDPOINT | 0x80,		// bSynchAddress
-	// Class-Specific AS Isochronous Audio Data Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
-	7,  					// bLength
-	0x25,  					// bDescriptorType, 0x25 = CS_ENDPOINT
-	1,  					// bDescriptorSubtype, 1 = EP_GENERAL
-	0x00,  					// bmAttributes
-	0,  					// bLockDelayUnits, 1 = ms
-	0x00, 0x00,  				// wLockDelay
-	// Standard AS Isochronous Audio Synch Endpoint Descriptor
-	// USB DCD for Audio Devices 1.0, Section 4.6.2.1, Table 4-22, page 63-64
-	9, 					// bLength
-	5, 					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
-	AUDIO_SYNC_ENDPOINT | 0x80,		// bEndpointAddress
-	0x11, 					// bmAttributes = isochronous, feedback
-	3, 0,					// wMaxPacketSize, 3 bytes
-	1,			 		// bInterval, 1 = every frame
-	5,					// bRefresh, 5 = 32ms
-	0,					// bSynchAddress
+      9,                              // bLength
+      4,                              // bDescriptorType, 4 = INTERFACE
+      AUDIO_INTERFACE,                // bInterfaceNumber
+      0,                              // bAlternateSetting
+      0,                              // bNumEndpoints
+      1,                              // bInterfaceClass, 1 = AUDIO
+      1,                              // bInterfaceSubclass, 1 = AUDIO_CONTROL
+      0,                              // bInterfaceProtocol
+      0,                              // iInterface
+      // Class-specific AC Interface Header Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-2, page 37-38
+      10,                              // bLength
+      0x24,                            // bDescriptorType, 0x24 = CS_INTERFACE
+      0x01,                            // bDescriptorSubtype, 1 = HEADER
+      0x00, 0x01,                      // bcdADC (version 1.0)
+      LSB(62), MSB(62),                // wTotalLength
+      2,                               // bInCollection
+      AUDIO_INTERFACE+1,               // baInterfaceNr(1) - Transmit to PC
+      AUDIO_INTERFACE+2,               // baInterfaceNr(2) - Receive from PC
+      // Input Terminal Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-3, page 39
+      12,                              // bLength
+      0x24,                            // bDescriptorType, 0x24 = CS_INTERFACE
+      0x02,                            // bDescriptorSubType, 2 = INPUT_TERMINAL
+      1,                               // bTerminalID
+      //0x01, 0x02,                    // wTerminalType, 0x0201 = MICROPHONE
+      //0x03, 0x06,                    // wTerminalType, 0x0603 = Line Connector
+      0x02, 0x06,                      // wTerminalType, 0x0602 = Digital Audio
+      0,                               // bAssocTerminal, 0 = unidirectional
+      AUDIO_CHANNELS,                  // bNrChannels
+      0x03, 0x00,                      // wChannelConfig, 0x0003 = Left & Right Front
+      0,                               // iChannelNames
+      0,                               // iTerminal
+      // Output Terminal Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-4, page 40
+      9,                              // bLength
+      0x24,                           // bDescriptorType, 0x24 = CS_INTERFACE
+      3,                              // bDescriptorSubtype, 3 = OUTPUT_TERMINAL
+      2,                              // bTerminalID
+      0x01, 0x01,                     // wTerminalType, 0x0101 = USB_STREAMING
+      0,                              // bAssocTerminal, 0 = unidirectional
+      1,                              // bCSourceID, connected to input terminal, ID=1
+      0,                              // iTerminal
+      // Input Terminal Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-3, page 39
+      12,                              // bLength
+      0x24,                            // bDescriptorType, 0x24 = CS_INTERFACE
+      2,                               // bDescriptorSubType, 2 = INPUT_TERMINAL
+      3,                               // bTerminalID
+      0x01, 0x01,                      // wTerminalType, 0x0101 = USB_STREAMING
+      0,                               // bAssocTerminal, 0 = unidirectional
+      AUDIO_CHANNELS,                  // bNrChannels
+      0x03, 0x00,                      // wChannelConfig, 0x0003 = Left & Right Front
+      0,                               // iChannelNames
+      0,                               // iTerminal
+      // Volume feature descriptor
+      10,                              // bLength
+      0x24,                            // bDescriptorType = CS_INTERFACE
+      0x06,                            // bDescriptorSubType = FEATURE_UNIT
+      0x31,                            // bUnitID
+      0x03,                            // bSourceID (Input Terminal)
+      0x01,                            // bControlSize (each channel is 1 byte, 3 channels)
+      0x01,                            // bmaControls(0) Master: Mute
+      0x02,                            // bmaControls(1) Left: Volume
+      0x02,                            // bmaControls(2) Right: Volume
+      0x00,                            // iFeature
+      // Output Terminal Descriptor
+      // USB DCD for Audio Devices 1.0, Table 4-4, page 40
+      9,                               // bLength
+      0x24,                            // bDescriptorType, 0x24 = CS_INTERFACE
+      3,                               // bDescriptorSubtype, 3 = OUTPUT_TERMINAL
+      4,                               // bTerminalID
+      //0x02, 0x03,                    // wTerminalType, 0x0302 = Headphones
+      0x02, 0x06,                      // wTerminalType, 0x0602 = Digital Audio
+      0,                               // bAssocTerminal, 0 = unidirectional
+      0x31,                            // bCSourceID, connected to feature, ID=31
+      0,                               // iTerminal
+      // Standard AS Interface Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
+      // Alternate 0: default setting, disabled zero bandwidth
+      9,                               // bLenght
+      4,                               // bDescriptorType = INTERFACE
+      AUDIO_INTERFACE+1,               // bInterfaceNumber
+      0,                               // bAlternateSetting
+      0,                               // bNumEndpoints
+      1,                               // bInterfaceClass, 1 = AUDIO
+      2,                               // bInterfaceSubclass, 2 = AUDIO_STREAMING
+      0,                               // bInterfaceProtocol
+      0,                               // iInterface
+      // Alternate 1: streaming data
+      9,                               // bLenght
+      4,                               // bDescriptorType = INTERFACE
+      AUDIO_INTERFACE+1,               // bInterfaceNumber
+      1,                               // bAlternateSetting
+      1,                               // bNumEndpoints
+      1,                               // bInterfaceClass, 1 = AUDIO
+      2,                               // bInterfaceSubclass, 2 = AUDIO_STREAMING
+      0,                               // bInterfaceProtocol
+      0,                               // iInterface
+      // Class-Specific AS Interface Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
+      7,                               // bLength
+      0x24,                            // bDescriptorType = CS_INTERFACE
+      1,                               // bDescriptorSubtype, 1 = AS_GENERAL
+      2,                               // bTerminalLink: Terminal ID = 2
+      3,                               // bDelay (approx 3ms delay, audio lib updates)
+      0x01, 0x00,                      // wFormatTag, 0x0001 = PCM
+      // Type I Format Descriptor
+      // USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
+      11,                              // bLength
+      0x24,                            // bDescriptorType = CS_INTERFACE
+      2,                               // bDescriptorSubtype = FORMAT_TYPE
+      1,                               // bFormatType = FORMAT_TYPE_I
+      AUDIO_CHANNELS,                  // bNrChannels = 2
+      AUDIO_SAMPLE_BYTES,              // bSubFrameSize = 2 byte
+      AUDIO_BIT_DEPTH,                 // bBitResolution = 16 bits
+      1,                               // bSamFreqType = 1 frequency
+      AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY), // tSamFreq
+      // Standard AS Isochronous Audio Data Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
+      9,                                // bLength
+      5,                                // bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
+      AUDIO_TX_EP | 0x80,               // bEndpointAddress
+      0x09,                             // bmAttributes = isochronous, adaptive
+      LSB(AUDIO_TX_SIZE), MSB(AUDIO_TX_SIZE),      // wMaxPacketSize
+      1,                                // bInterval, 1 = every frame
+      0,                                // bRefresh
+      0,                                // bSynchAddress
+      // Class-Specific AS Isochronous Audio Data Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
+      7,                                // bLength
+      0x25,                             // bDescriptorType, 0x25 = CS_ENDPOINT
+      1,                                // bDescriptorSubtype, 1 = EP_GENERAL
+      0x00,                             // bmAttributes
+      0,                                // bLockDelayUnits, 1 = ms
+      0x00, 0x00,                       // wLockDelay
+      // Standard AS Interface Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.5.1, Table 4-18, page 59
+      // Alternate 0: default setting, disabled zero bandwidth
+      9,                                // bLenght
+      4,                                // bDescriptorType = INTERFACE
+      AUDIO_INTERFACE+2,                // bInterfaceNumber
+      0,                                // bAlternateSetting
+      0,                                // bNumEndpoints
+      1,                                // bInterfaceClass, 1 = AUDIO
+      2,                                // bInterfaceSubclass, 2 = AUDIO_STREAMING
+      0,                                // bInterfaceProtocol
+      0,                                // iInterface
+      // Alternate 1: streaming data
+      9,                                // bLenght
+      4,                                // bDescriptorType = INTERFACE
+      AUDIO_INTERFACE+2,                // bInterfaceNumber
+      1,                                // bAlternateSetting
+      2,                                // bNumEndpoints
+      1,                                // bInterfaceClass, 1 = AUDIO
+      2,                                // bInterfaceSubclass, 2 = AUDIO_STREAMING
+      0,                                // bInterfaceProtocol
+      0,                                // iInterface
+      // Class-Specific AS Interface Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.5.2, Table 4-19, page 60
+      7,                                // bLength
+      0x24,                             // bDescriptorType = CS_INTERFACE
+      1,                                // bDescriptorSubtype, 1 = AS_GENERAL
+      3,                                // bTerminalLink: Terminal ID = 3
+      3,                                // bDelay (approx 3ms delay, audio lib updates)
+      0x01, 0x00,                       // wFormatTag, 0x0001 = PCM
+      // Type I Format Descriptor
+      // USB DCD for Audio Data Formats 1.0, Section 2.2.5, Table 2-1, page 10
+      11,                               // bLength
+      0x24,                             // bDescriptorType = CS_INTERFACE
+      2,                                // bDescriptorSubtype = FORMAT_TYPE
+      1,                                // bFormatType = FORMAT_TYPE_I
+      AUDIO_CHANNELS,                   // bNrChannels = 2
+      AUDIO_SAMPLE_BYTES,               // bSubFrameSize = 2 byte
+      AUDIO_BIT_DEPTH,                  // bBitResolution = 16 bits
+      1,                                // bSamFreqType = 1 frequency
+      AUDIO_SAMPLE_FREQ((int) AUDIO_FREQUENCY), // tSamFreq
+      // Standard AS Isochronous Audio Data Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
+      9,                                // bLength
+      5,                                // bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
+      AUDIO_RX_EP,                      // bEndpointAddress
+      0x05,                             // bmAttributes = isochronous, asynchronous
+      LSB(AUDIO_RX_SIZE), MSB(AUDIO_RX_SIZE),      // wMaxPacketSize
+      1,                                // bInterval, 1 = every frame
+      0,                                // bRefresh
+      AUDIO_SYNC_ENDPOINT | 0x80,       // bSynchAddress
+      // Class-Specific AS Isochronous Audio Data Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.1.2, Table 4-21, page 62-63
+      7,                                // bLength
+      0x25,                             // bDescriptorType, 0x25 = CS_ENDPOINT
+      1,                                // bDescriptorSubtype, 1 = EP_GENERAL
+      0x00,                             // bmAttributes
+      0,                                // bLockDelayUnits, 1 = ms
+      0x00, 0x00,                       // wLockDelay
+      // Standard AS Isochronous Audio Synch Endpoint Descriptor
+      // USB DCD for Audio Devices 1.0, Section 4.6.2.1, Table 4-22, page 63-64
+      9,                                // bLength
+      5,                                // bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
+      AUDIO_SYNC_ENDPOINT | 0x80,       // bEndpointAddress
+      0x11,                             // bmAttributes = isochronous, feedback
+      3, 0,                             // wMaxPacketSize, 3 bytes
+      1,                                // bInterval, 1 = every frame
+      5,                                // bRefresh, 5 = 32ms
+      0,                                // bSynchAddress
 #endif
 
 #ifdef MULTITOUCH_INTERFACE

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -774,6 +774,32 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_ISOCHRONOUS + ENDPOINT_TRANSMIT_ISOCHRONOUS
   #define ENDPOINT4_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_ISOCHRONOUS
 
+  // Associated constants and helper functions for USB Audio
+  #define AUDIO_SAMPLE_FREQ(frq) (uint8_t)(frq), (uint8_t)((frq >> 8)), (uint8_t)((frq >> 16))
+  // Max packet size: (freq / 1000 + extra_samples) * channels * bytes_per_sample
+  // e.g. (48000 / 1000 + 1) * 2(stereo) * 3(24bit) = 388
+  #define AUDIO_PACKET_SZE_24B(frq) (uint8_t)(((frq / 1000U + 1) * 4U * 3U) & 0xFFU), \
+                                    (uint8_t)((((frq / 1000U + 1) * 4U * 3U) >> 8) & 0xFFU)
+  #define AUDIO_CONTROL_MUTE 0x01
+  #define AUDIO_CONTROL_VOL 0x02
+  #define AUDIO_FORMAT_TYPE_I 0x01
+  #define USB_DESC_TYPE_INTERFACE 0x04
+  #define USB_DESC_TYPE_ENDPOINT 0x05
+
+  #define CS_DESC_TYPE_INTERFACE 0x24
+  #define CS_DESC_TYPE_ENDPOINT 0x25
+  #define CS_DESC_SUBTYPE_FORMAT 0x02
+  #define CS_DESC_SUBTYPE_EP_GENERAL 0x01
+  #define CS_DESC_SUBTYPE_AS_GENERAL 0x01
+  #define CS_DESC_SUBTYPE_INPUT_TERMINAL 0x02
+  #define CS_DESC_SUBTYPE_OUTPUT_TERMINAL 0x03
+  #define CS_DESC_SUBTYPE_FEATURE_UNIT 0x06
+
+  #define AUDIO_EP_IN_MASK 0x80 // A mask used to indicate a specified endpoint ID is an input
+  #define AUDIO_EP_TYPE_ISOC 0x01 // Isochronous Endpoint Type
+  #define AUDIO_EP_TYPE_ADAPTIVE 0x08 // Isochronous Endpoint Type
+  #define AUDIO_EP_TYPE_ASYNC 0x04 // Isochronous Endpoint Type
+
 #elif defined(USB_MIDI_AUDIO_SERIAL)
   #define VENDOR_ID		0x16C0
   #define PRODUCT_ID		0x048A

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -761,13 +761,13 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define SEREMU_RX_SIZE        32
   #define SEREMU_RX_INTERVAL    2
   #define AUDIO_INTERFACE	1	// Audio (uses 3 consecutive interfaces)
-  #define AUDIO_TX_ENDPOINT     3
+  #define AUDIO_TX_EP     3
   #define AUDIO_CHANNELS        8 // Must be a multiple of 2
   #define AUDIO_FREQUENCY       AUDIO_SAMPLE_RATE_EXACT
   #define AUDIO_SAMPLE_BYTES    (sizeof ((audio_block_t*) 0)->data[0])
   #define AUDIO_BIT_DEPTH       (AUDIO_SAMPLE_BYTES * 8)
   #define AUDIO_TX_SIZE         ((int)(AUDIO_FREQUENCY / 1000U) + 1) * AUDIO_CHANNELS * AUDIO_SAMPLE_BYTES
-  #define AUDIO_RX_ENDPOINT     3
+  #define AUDIO_RX_EP     3
   #define AUDIO_RX_SIZE         AUDIO_TX_SIZE
   #define AUDIO_SYNC_ENDPOINT	4
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_INTERRUPT + ENDPOINT_TRANSMIT_INTERRUPT


### PR DESCRIPTION
Began just reading through the USB Audio Specification (and its various auxiliary PDFs...) trying to verify and compare the Teensy's descriptor to the documentation.

Includes a couple correctness fixes. Decided to make this a general task of documenting random magic numbers as well.

# Errata
- [x] bInterval was specified as 4ms, while in the USB Audio 1.0 spec it must be 1ms.
- [x] The OUTPUT section of the USB Audio Descriptor is *not* asynchronous, and has no feedback endpoint. It reports itself as adaptive.